### PR TITLE
Feature: Add permissions support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ pom.xml.asc
 .hgignore
 .hg/
 /third-party
+/data/cache

--- a/README.md
+++ b/README.md
@@ -42,7 +42,13 @@ Similarly, for just the integration tests:
 $ lein ltest :integration
 ```
 
-The default behaviour of `lein ltest` runs all tests types.
+Just system tests:
+```
+$ lein ltest :system
+```
+
+The default behaviour of `lein ltest` runs both unit and integration. To run
+all tests, use `lein ltest :all`.
 
 
 ## Documentation [&#x219F;](#contents)

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ Just system tests:
 $ lein ltest :system
 ```
 
-The default behaviour of `lein ltest` runs both unit and integration. To run
-all tests, use `lein ltest :all`.
+The default behaviour of `lein ltest` runs both unit and integration tests. To
+run all tests, use `lein ltest :all`.
 
 
 ## Documentation [&#x219F;](#contents)
@@ -95,7 +95,6 @@ Then bring up the system:
 ```
 ```
 2018-04-07T15:26:54.830 [nREPL-worker-0] INFO cmr.opendap.components.config:62 - Starting config component ...
-2018-04-07T15:26:54.834 [nREPL-worker-0] DEBUG cmr.opendap.components.config:63 - Started config component.
 2018-04-07T15:26:54.837 [nREPL-worker-0] INFO cmr.opendap.components.logging:22 - Starting logging component ...
 2018-04-07T15:26:54.845 [nREPL-worker-0] INFO cmr.opendap.components.caching:56 - Starting caching component ...
 2018-04-07T15:26:54.855 [nREPL-worker-0] INFO cmr.opendap.components.httpd:23 - Starting httpd component ...

--- a/dev-resources/src/cmr/opendap/dev.clj
+++ b/dev-resources/src/cmr/opendap/dev.clj
@@ -11,6 +11,7 @@
     [cmr.opendap.components.config :as config]
     [cmr.opendap.components.core]
     [com.stuartsierra.component :as component]
+    [org.httpkit.client :as httpc]
     [trifl.java :refer [show-methods]])
   (:import
     (java.net URI)

--- a/dev-resources/src/cmr/opendap/dev.clj
+++ b/dev-resources/src/cmr/opendap/dev.clj
@@ -3,6 +3,7 @@
   (:require
     [clojure.java.io :as io]
     [clojure.pprint :refer [pprint]]
+    [clojure.set :as set]
     [clojure.tools.namespace.repl :as repl]
     [clojusc.dev.system.core :as system-api]
     [clojusc.twig :as logger]

--- a/dev-resources/src/user.clj
+++ b/dev-resources/src/user.clj
@@ -7,11 +7,11 @@
   that supports startup and shutdown."
   (:require
    [cheshire.core :as json]
-   [clj-http.client :as httpc]
    [clojure.java.io :as io]
    [clojure.pprint :refer [pprint]]
    [clojure.tools.namespace.repl :as repl]
-   [cmr.opendap.dev :as dev]))
+   [cmr.opendap.dev :as dev]
+   [org.httpkit.client :as httpc]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;   State Management   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/project.clj
+++ b/project.clj
@@ -27,7 +27,6 @@
     [clojusc/trifl "0.2.0"]
     [clojusc/twig "0.3.2"]
     [com.stuartsierra/component "0.3.2"]
-    [gov.nasa.earthdata/cmr-client "0.3.0-SNAPSHOT"]
     [http-kit "2.2.0"]
     [metosin/reitit-core "0.1.1-SNAPSHOT"]
     [metosin/reitit-ring "0.1.1-SNAPSHOT"]

--- a/project.clj
+++ b/project.clj
@@ -27,6 +27,7 @@
     [clojusc/trifl "0.2.0"]
     [clojusc/twig "0.3.2"]
     [com.stuartsierra/component "0.3.2"]
+    [gov.nasa.earthdata/cmr-client "0.3.0-SNAPSHOT"]
     [http-kit "2.2.0"]
     [metosin/reitit-core "0.1.1-SNAPSHOT"]
     [metosin/reitit-ring "0.1.1-SNAPSHOT"]

--- a/project.clj
+++ b/project.clj
@@ -34,6 +34,7 @@
     [metosin/ring-http-response "0.9.0"]
     [org.clojure/clojure "1.9.0"]
     [org.clojure/core.cache "0.7.1"]
+    [org.clojure/data.xml "0.2.0-alpha5"]
     [ring/ring-core "1.6.3"]
     [ring/ring-codec "1.1.0"]
     [ring/ring-defaults "0.3.1"]]

--- a/project.clj
+++ b/project.clj
@@ -23,7 +23,6 @@
     :url "http://www.apache.org/licenses/LICENSE-2.0"}
   :dependencies [
     [cheshire "5.8.0"]
-    [clj-http "3.8.0"]
     [clojusc/trifl "0.2.0"]
     [clojusc/twig "0.3.2"]
     [com.stuartsierra/component "0.3.2"]

--- a/project.clj
+++ b/project.clj
@@ -69,8 +69,10 @@
       :plugins [
         [lein-ltest "0.3.0"]]
       :test-selectors {
-        :unit (complement :integration)
-        :integration :integration}}
+        :unit #(not (or (:integration %) (:system %)))
+        :integration :integration
+        :system :system
+        :default (complement :system)}}
     :docs {
       :dependencies [
         [clojang/codox-theme "0.2.0-SNAPSHOT"]]
@@ -117,14 +119,4 @@
       ["marginalia"]]
     ;; Application
     "start-cmr-opendap"
-      ["trampoline" "run"]
-    ;; Docker Aliases
-    "docker-clean" [
-      "shell"
-      "docker" "system" "prune" "-f"]
-    "start-infra" [
-      "shell"
-      "docker-compose" "-f" "resources/docker/docker-compose.yml" "up"]
-    "stop-infra" [
-      "shell"
-      "docker-compose" "-f" "resources/docker/docker-compose.yml" "down"]})
+      ["trampoline" "run"]})

--- a/resources/config/cmr-opendap/config.edn
+++ b/resources/config/cmr-opendap/config.edn
@@ -3,7 +3,8 @@
    :ttl
     {:minutes 60}
    :lru
-    {:threshold 1000}}
+    {:threshold 1000}
+   :dumpfile "data/cache/dump.edn"}
  :cmr
   {:base-url "https://cmr.sit.earthdata.nasa.gov"}
  :httpd

--- a/resources/config/cmr-opendap/config.edn
+++ b/resources/config/cmr-opendap/config.edn
@@ -4,9 +4,11 @@
     {:minutes 60}
    :lru
     {:threshold 1000}}
+ :cmr
+  {:base-url "https://cmr.sit.earthdata.nasa.gov"}
  :httpd
   {:port 3012
    :docroot "public"}
  :logging
   {:level :debug
-   :nss [cmr.opendap]}}
+   :nss [cmr.opendap org.httpkit]}}

--- a/src/cmr/opendap/auth/acls.clj
+++ b/src/cmr/opendap/auth/acls.clj
@@ -1,0 +1,34 @@
+(ns cmr.opendap.auth.acls
+  (:require
+   [cheshire.core :as json]
+   [clojure.set :as set]
+   [cmr.opendap.components.caching :as caching]
+   [cmr.opendap.http.request :as request]
+   [cmr.opendap.http.response :as response]
+   [org.httpkit.client :as httpc]
+   [taoensso.timbre :as log]))
+
+(def acl-resource "/access-control/permissions")
+
+(defn parse-response
+  [data]
+  (let [str-data (slurp data)
+        json-data (json/parse-string str-data true)]
+    (log/debug "str-data:" str-data)
+    (log/debug "json-data:" json-data)
+    json-data))
+
+(defn check-access
+  [base-url token user-id acl-query]
+  (let [url (str base-url acl-resource)]
+    (httpc/request (-> request/default-options
+                       (request/options
+                        :method :get
+                        :url url
+                        :query-params (merge
+                                       {:user_id user-id}
+                                       acl-query))
+                       (request/add-token-header token)
+                       (request/add-client-id)
+                       ((fn [x] (log/trace "Prepared request:" x) x)))
+                    #(response/client-handler % parse-response))))

--- a/src/cmr/opendap/auth/core.clj
+++ b/src/cmr/opendap/auth/core.clj
@@ -53,8 +53,9 @@
                user-id)
 
               route-permissions
-              (check-permissions system handler request route-permissions
-               cmr-base-url user-token user-id))))
+              (check-permissions
+               system handler request route-permissions cmr-base-url
+               user-token user-id))))
     (do
       (log/warn "ECHO token not provided for protected resource")
       (response/not-allowed errors/token-required))))
@@ -62,8 +63,8 @@
 (defn check-route-access
   [system handler request]
   ;; Before performing any GETs/POSTs against CMR Access Control or ECHO,
-  ;; let's make sure that's actually necessary, only doing it in the event
-  ;; that the route is annotated for roles/permissions.
+  ;; let's make sure that's actually necessary, only doing it in the cases
+  ;; where the route is annotated for roles/permissions.
   (let [route-roles (roles/route-annotation request)
         route-permissions (permissions/route-annotation request)]
     (if (or route-roles route-permissions)
@@ -72,7 +73,8 @@
                         "routes; checking ACLs ..."))
         (log/debug "route-roles:" route-roles)
         (log/debug "route-permissions:" route-permissions)
-        (check-roles-permissions system handler request route-roles route-permissions))
+        (check-roles-permissions
+         system handler request route-roles route-permissions))
       (do
         (log/debug (str "Neither roles nor permissions were annotated in "
                         "the routes; skipping ACL check ..."))

--- a/src/cmr/opendap/auth/core.clj
+++ b/src/cmr/opendap/auth/core.clj
@@ -1,0 +1,79 @@
+(ns cmr.opendap.auth.core
+  (:require
+   [cmr.opendap.auth.permissions :as permissions]
+   [cmr.opendap.auth.roles :as roles]
+   [cmr.opendap.auth.token :as token]
+   [cmr.opendap.components.caching :as caching]
+   [cmr.opendap.components.config :as config]
+   [cmr.opendap.errors :as errors]
+   [cmr.opendap.http.response :as response]
+   [taoensso.timbre :as log]))
+
+(defn check-roles
+  [system handler request route-roles cmr-base-url user-token user-id]
+  (log/debug "Roles annotated in routes ...")
+  (if (roles/admin? system
+                    route-roles
+                    cmr-base-url
+                    user-token
+                    user-id)
+    (handler request)
+    (response/not-allowed errors/no-permissions)))
+
+(defn check-permissions
+  [system handler request route-permissions cmr-base-url user-token user-id]
+  (let [concept-id (permissions/route-concept-id request)]
+    (log/debug "Permissions annotated in routes ...")
+    (if (permissions/concept? system
+                              route-permissions
+                              cmr-base-url
+                              user-token
+                              user-id
+                              concept-id)
+      (handler request)
+      (response/not-allowed errors/no-permissions))))
+
+(defn check-roles-permissions
+  [system handler request route-roles route-permissions]
+  (if-let [user-token (token/extract request)]
+    (do
+      (log/debug "ECHO token provided; proceeding ...")
+      (let [cmr-base-url (config/cmr-base-url system)
+            user-id (token/->cached-user system cmr-base-url user-token)]
+        (log/trace "cmr-base-url:" cmr-base-url)
+        (log/trace "user-token:" user-token)
+        (log/trace "user-id:" user-id)
+        (cond ;; XXX For now, there is only the admin role in the CMR, so
+              ;;     we'll just keep this specific to that for now. Later, if
+              ;;     more roles are used, we'll want to make this more
+              ;;     generic ...
+              route-roles
+              (check-roles
+               system handler request route-roles cmr-base-url user-token
+               user-id)
+
+              route-permissions
+              (check-permissions system handler request route-permissions
+               cmr-base-url user-token user-id))))
+    (do
+      (log/warn "ECHO token not provided for protected resource")
+      (response/not-allowed errors/token-required))))
+
+(defn check-route-access
+  [system handler request]
+  ;; Before performing any GETs/POSTs against CMR Access Control or ECHO,
+  ;; let's make sure that's actually necessary, only doing it in the event
+  ;; that the route is annotated for roles/permissions.
+  (let [route-roles (roles/route-annotation request)
+        route-permissions (permissions/route-annotation request)]
+    (if (or route-roles route-permissions)
+      (do
+        (log/debug (str "Either roles or permissions were annotated in "
+                        "routes; checking ACLs ..."))
+        (log/debug "route-roles:" route-roles)
+        (log/debug "route-permissions:" route-permissions)
+        (check-roles-permissions system handler request route-roles route-permissions))
+      (do
+        (log/debug (str "Neither roles nor permissions were annotated in "
+                        "the routes; skipping ACL check ..."))
+        (handler request)))))

--- a/src/cmr/opendap/auth/permissions.clj
+++ b/src/cmr/opendap/auth/permissions.clj
@@ -9,11 +9,6 @@
    [taoensso.timbre :as log]))
 
 (def permissions-resource "/access-control/permissions")
-(def management-acl :INGEST_MANAGEMENT_ACL)
-
-(defn admin-key
-  [token]
-  (str "admin:" token))
 
 (defn parse-acl-permissions
   [data]
@@ -37,29 +32,6 @@
                        (request/add-client-id)
                        ((fn [x] (log/trace "Prepared request:" x) x)))
                     #(response/client-handler % parse-acl-permissions))))
-
-(defn admin
-  [base-url token user-id]
-  (let [perms (acl
-               base-url
-               token
-               user-id
-               {:system_object (name management-acl)})]
-    (if (seq (management-acl @perms))
-      #{:admin}
-      #{})))
-
-(defn cached-admin
-  [system base-url token user-id]
-  (caching/lookup
-   system
-   (admin-key token)
-   #(admin base-url token user-id)))
-
-(defn admin?
-  [system roles base-url token user-id]
-  (seq (set/intersection (cached-admin system base-url token user-id)
-                         roles)))
 
 (defn concept?
   [base-url token user-id concept-id]

--- a/src/cmr/opendap/auth/permissions.clj
+++ b/src/cmr/opendap/auth/permissions.clj
@@ -1,0 +1,66 @@
+(ns cmr.opendap.auth.permissions
+  (:require
+   [cheshire.core :as json]
+   [clojure.set :as set]
+   [cmr.opendap.components.caching :as caching]
+   [cmr.opendap.http.request :as request]
+   [cmr.opendap.http.response :as response]
+   [org.httpkit.client :as httpc]
+   [taoensso.timbre :as log]))
+
+(def permissions-resource "/access-control/permissions")
+(def management-acl :INGEST_MANAGEMENT_ACL)
+
+(defn admin-key
+  [token]
+  (str "admin:" token))
+
+(defn parse-acl-permissions
+  [data]
+  (let [str-data (slurp data)
+        json-data (json/parse-string str-data true)]
+    (log/debug "str-data:" str-data)
+    (log/debug "json-data:" json-data)
+    json-data))
+
+(defn acl
+  [base-url token user-id acl-query]
+  (let [url (str base-url permissions-resource)]
+    (httpc/request (-> request/default-options
+                       (request/options
+                        :method :get
+                        :url url
+                        :query-params (merge
+                                       {:user_id user-id}
+                                       acl-query))
+                       (request/add-token-header token)
+                       (request/add-client-id)
+                       ((fn [x] (log/trace "Prepared request:" x) x)))
+                    #(response/client-handler % parse-acl-permissions))))
+
+(defn admin
+  [base-url token user-id]
+  (let [perms (acl
+               base-url
+               token
+               user-id
+               {:system_object (name management-acl)})]
+    (if (seq (management-acl @perms))
+      #{:admin}
+      #{})))
+
+(defn cached-admin
+  [system base-url token user-id]
+  (caching/lookup
+   system
+   (admin-key token)
+   #(admin base-url token user-id)))
+
+(defn admin?
+  [system roles base-url token user-id]
+  (seq (set/intersection (cached-admin system base-url token user-id)
+                         roles)))
+
+(defn concept?
+  [base-url token user-id concept-id]
+  (acl base-url token user-id {:concept_id concept-id}))

--- a/src/cmr/opendap/auth/permissions.clj
+++ b/src/cmr/opendap/auth/permissions.clj
@@ -5,3 +5,60 @@
    [cmr.opendap.components.caching :as caching]
    [reitit.ring :as ring]
    [taoensso.timbre :as log]))
+
+(def echo-concept-query #(hash-map :concept_id %))
+
+(defn concept-key
+  [token]
+  (str "concept:" token))
+
+(defn reitit-acl-data
+  [concept-id annotation]
+  (when (and concept-id annotation)
+    {concept-id annotation}))
+
+(defn cmr-acl->reitit-acl
+  [cmr-acl]
+  (log/debug "Got CMR ACL:" cmr-acl)
+  (cond (nil? cmr-acl) #{}
+        :else cmr-acl))
+
+(defn route-concept-id
+  [request]
+  (get-in request [:path-params :concept-id]))
+
+(defn route-annotation
+  "It is expected that the route annotation for permissions is of the form:
+
+  :METHOD {:handler ...
+           :permissions #{...}}
+
+  Supported elements of the :permissions set is currently just :read."
+  [request]
+  (log/trace "Request:" request)
+  (reitit-acl-data
+   (route-concept-id request)
+   (get-in (ring/get-match request) [:data :get :permissions])))
+
+(defn concept
+  [base-url token user-id concept-id]
+  (let [perms (acls/check-access base-url
+                                 token
+                                 user-id
+                                 (echo-concept-query concept-id))]
+    (cmr-acl->reitit-acl @perms)))
+
+(defn cached-concept
+  [system base-url token user-id concept-id]
+  (caching/lookup system
+                  (concept-key token)
+                  #(concept base-url token user-id concept-id)))
+
+(defn concept?
+  [system roles base-url token user-id concept-id]
+  (seq (set/intersection (cached-concept system
+                                         base-url
+                                         token
+                                         user-id
+                                         concept-id)
+                         roles)))

--- a/src/cmr/opendap/auth/permissions.clj
+++ b/src/cmr/opendap/auth/permissions.clj
@@ -1,38 +1,7 @@
 (ns cmr.opendap.auth.permissions
   (:require
-   [cheshire.core :as json]
    [clojure.set :as set]
+   [cmr.opendap.auth.acls :as acls]
    [cmr.opendap.components.caching :as caching]
-   [cmr.opendap.http.request :as request]
-   [cmr.opendap.http.response :as response]
-   [org.httpkit.client :as httpc]
+   [reitit.ring :as ring]
    [taoensso.timbre :as log]))
-
-(def permissions-resource "/access-control/permissions")
-
-(defn parse-acl-permissions
-  [data]
-  (let [str-data (slurp data)
-        json-data (json/parse-string str-data true)]
-    (log/debug "str-data:" str-data)
-    (log/debug "json-data:" json-data)
-    json-data))
-
-(defn acl
-  [base-url token user-id acl-query]
-  (let [url (str base-url permissions-resource)]
-    (httpc/request (-> request/default-options
-                       (request/options
-                        :method :get
-                        :url url
-                        :query-params (merge
-                                       {:user_id user-id}
-                                       acl-query))
-                       (request/add-token-header token)
-                       (request/add-client-id)
-                       ((fn [x] (log/trace "Prepared request:" x) x)))
-                    #(response/client-handler % parse-acl-permissions))))
-
-(defn concept?
-  [base-url token user-id concept-id]
-  (acl base-url token user-id {:concept_id concept-id}))

--- a/src/cmr/opendap/auth/roles.clj
+++ b/src/cmr/opendap/auth/roles.clj
@@ -1,3 +1,44 @@
 (ns cmr.opendap.auth.roles
   (:require
+   [clojure.set :as set]
+   [cmr.opendap.auth.permissions :as permissions]
+   [cmr.opendap.components.caching :as caching]
+   [reitit.ring :as ring]
    [taoensso.timbre :as log]))
+
+(def management-acl :INGEST_MANAGEMENT_ACL)
+
+(defn route-annotation
+  "It is expected that the route annotation for roles is of the form:
+
+  :METHOD {:handler ...
+           :roles #{...}}
+
+  Note that currently, only the :admin role is supported."
+  [request]
+  (get-in (ring/get-match request) [:data :get :roles]))
+
+(defn admin-key
+  [token]
+  (str "admin:" token))
+
+(defn admin
+  [base-url token user-id]
+  (let [perms (permissions/acl base-url
+                               token
+                               user-id
+                               {:system_object (name management-acl)})]
+    (if (seq (management-acl @perms))
+      #{:admin}
+      #{})))
+
+(defn cached-admin
+  [system base-url token user-id]
+  (caching/lookup system
+                  (admin-key token)
+                  #(admin base-url token user-id)))
+
+(defn admin?
+  [system roles base-url token user-id]
+  (seq (set/intersection (cached-admin system base-url token user-id)
+                         roles)))

--- a/src/cmr/opendap/auth/roles.clj
+++ b/src/cmr/opendap/auth/roles.clj
@@ -1,0 +1,3 @@
+(ns cmr.opendap.auth.roles
+  (:require
+   [taoensso.timbre :as log]))

--- a/src/cmr/opendap/auth/roles.clj
+++ b/src/cmr/opendap/auth/roles.clj
@@ -9,6 +9,16 @@
 (def management-acl :INGEST_MANAGEMENT_ACL)
 (def echo-management-query {:system_object (name management-acl)})
 
+(defn admin-key
+  [token]
+  (str "admin:" token))
+
+(defn cmr-acl->reitit-acl
+  [cmr-acl]
+  (if (seq (management-acl cmr-acl))
+    #{:admin}
+    #{}))
+
 (defn route-annotation
   "It is expected that the route annotation for roles is of the form:
 
@@ -19,19 +29,13 @@
   [request]
   (get-in (ring/get-match request) [:data :get :roles]))
 
-(defn admin-key
-  [token]
-  (str "admin:" token))
-
 (defn admin
   [base-url token user-id]
   (let [perms (acls/check-access base-url
                                  token
                                  user-id
                                  echo-management-query)]
-    (if (seq (management-acl @perms))
-      #{:admin}
-      #{})))
+    (cmr-acl->reitit-acl @perms)))
 
 (defn cached-admin
   [system base-url token user-id]

--- a/src/cmr/opendap/auth/token.clj
+++ b/src/cmr/opendap/auth/token.clj
@@ -24,7 +24,7 @@
 
 (defn parse-token-data
   [xml-str]
-  (log/debug "Got token XML data:" xml-str)
+  (log/trace "Got token XML data:" xml-str)
   (first
     (remove nil?
       (mapcat #(when (map? %)

--- a/src/cmr/opendap/auth/token.clj
+++ b/src/cmr/opendap/auth/token.clj
@@ -1,0 +1,55 @@
+(ns cmr.opendap.auth.token
+  (:require
+   [clojure.data.xml :as xml]
+   [cmr.opendap.components.caching :as caching]
+   [cmr.opendap.const :as const]
+   [cmr.opendap.http.request :as request]
+   [cmr.opendap.http.response :as response]
+   [org.httpkit.client :as httpc]
+   [taoensso.timbre :as log]))
+
+(def token-info-resource "/legacy-services/rest/tokens/get_token_info")
+
+(defn token-data-key
+  [token]
+  (str "token-data:" token))
+
+(defn user-id-key
+  [token]
+  (str "user-id:" token))
+
+(defn extract
+  [request]
+  (request/get-header request "echo-token"))
+
+(defn parse-token-data
+  [xml-str]
+  (log/debug "Got token XML data:" xml-str)
+  (first
+    (remove nil?
+      (mapcat #(when (map? %)
+                (when (= :user_name (:tag %)) (:content %)))
+              (:content (xml/parse-str xml-str))))))
+
+(defn get-token-info
+  [base-url token]
+  (let [url (str base-url token-info-resource)
+        data (str "id=" token)]
+    (httpc/request (-> request/default-options
+                       (request/options :method :post :url url :body data)
+                       (request/add-token-header token)
+                       (request/add-form-ct)
+                       (request/add-client-id)
+                       ((fn [x] (log/trace "Prepared request:" x) x)))
+                   #(response/client-handler % parse-token-data))))
+
+(defn ->user
+  [base-url token]
+  @(get-token-info base-url token))
+
+(defn ->cached-user
+  [system base-url token]
+  (caching/lookup
+   system
+   (user-id-key token)
+   #(->user base-url token)))

--- a/src/cmr/opendap/components/caching.clj
+++ b/src/cmr/opendap/components/caching.clj
@@ -14,8 +14,10 @@
   [system]
   (if-let [sys system]
     (if-let [filename (config/cache-dumpfile system)]
-      (read-string
-        (slurp filename)))))
+      (try
+        (read-string
+          (slurp filename))
+        (catch Exception _ nil)))))
 
 (defn dump-cache
   [system cache-data]

--- a/src/cmr/opendap/components/config.clj
+++ b/src/cmr/opendap/components/config.clj
@@ -16,6 +16,10 @@
 ;;;   Config Component API   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(defn cache-dumpfile
+  [system]
+  (get-in (get-cfg system) [:caching :dumpfile]))
+
 (defn cache-init
   [system]
   (get-in (get-cfg system) [:caching :init]))

--- a/src/cmr/opendap/components/config.clj
+++ b/src/cmr/opendap/components/config.clj
@@ -35,6 +35,10 @@
   [system]
   (get-in (get-cfg system) [:caching :type]))
 
+(defn cmr-base-url
+  [system]
+  (get-in (get-cfg system) [:cmr :base-url]))
+
 (defn http-docroot
   [system]
   (get-in (get-cfg system) [:httpd :docroot]))

--- a/src/cmr/opendap/components/core.clj
+++ b/src/cmr/opendap/components/core.clj
@@ -28,6 +28,11 @@
            (httpd/create-component)
            [:config :logging :caching])})
 
+(def cache-without-logging
+  {:caching (component/using
+             (caching/create-component)
+             [:config])})
+
 (def httpd-without-logging
   {:httpd (component/using
            (httpd/create-component)
@@ -55,6 +60,7 @@
   []
   (component/map->SystemMap
     (merge cfg
+           cache-without-logging
            httpd-without-logging)))
 
 (def init-lookup

--- a/src/cmr/opendap/const.clj
+++ b/src/cmr/opendap/const.clj
@@ -1,0 +1,4 @@
+(ns cmr.opendap.const)
+
+(def user-agent
+  "CMR OPeNDAP Service/1.0 (+https://github.com/cmr-exchange/cmr-opendap)")

--- a/src/cmr/opendap/errors.clj
+++ b/src/cmr/opendap/errors.clj
@@ -1,0 +1,4 @@
+(ns cmr.opendap.errors)
+
+(def no-permissions "You do not have permissions to access that resource.")
+(def token-required "An ECHO token is required to access this resource.")

--- a/src/cmr/opendap/health.clj
+++ b/src/cmr/opendap/health.clj
@@ -1,6 +1,4 @@
-(ns cmr.opendap.health
-  (:require
-   [clj-http.client :as httpc]))
+(ns cmr.opendap.health)
 
 (defn has-data?
   [x]

--- a/src/cmr/opendap/http/request.clj
+++ b/src/cmr/opendap/http/request.clj
@@ -1,0 +1,35 @@
+(ns cmr.opendap.http.request
+  (:require
+   [cmr.opendap.const :as const]
+   [org.httpkit.client :as httpc]
+   [taoensso.timbre :as log]))
+
+(def default-options
+  {:user-agent const/user-agent
+   :insecure? true})
+
+(defn options
+  [request & opts]
+  (apply assoc (concat [request] opts)))
+
+(defn get-header
+  [request field]
+  (get-in request [:headers field]))
+
+(defn add-header
+  [request field value]
+  (assoc-in request [:headers field] value))
+
+(defn add-token-header
+  [request token]
+  (add-header request "Echo-Token" token))
+
+(defn add-form-ct
+  [request]
+  (add-header request "Content-Type" "application/x-www-form-urlencoded"))
+
+(defn add-client-id
+  [request]
+  (add-header request "Client-Id" "cmr-opendap-token-checker"))
+
+

--- a/src/cmr/opendap/http/response.clj
+++ b/src/cmr/opendap/http/response.clj
@@ -13,8 +13,7 @@
   [{:keys [status headers body error]} parse-fn]
   (log/debug "Handling client response ...")
   (cond error
-        (do
-          (log/error error))
+        (log/error error)
         (>= status 400)
         (do
           (log/error status)

--- a/src/cmr/opendap/rest/app.clj
+++ b/src/cmr/opendap/rest/app.clj
@@ -20,7 +20,7 @@
   [httpd-component]
   (-> httpd-component
       rest-api-routes
-      (ring/router (middleware/reitit-acls httpd-component))
+      (ring/router (middleware/reitit-auth httpd-component))
       (ring/ring-handler handler/fallback)
       (ring-defaults/wrap-defaults ring-defaults/api-defaults)
       (middleware/wrap-cors)))

--- a/src/cmr/opendap/rest/app.clj
+++ b/src/cmr/opendap/rest/app.clj
@@ -20,7 +20,7 @@
   [httpd-component]
   (-> httpd-component
       rest-api-routes
-      (ring/router {:data {:middleware [middleware/wrap-enforce-roles]}})
+      (ring/router (middleware/reitit-enforce-roles httpd-component))
       (ring/ring-handler handler/fallback)
       (ring-defaults/wrap-defaults ring-defaults/api-defaults)
       (middleware/wrap-cors)))

--- a/src/cmr/opendap/rest/app.clj
+++ b/src/cmr/opendap/rest/app.clj
@@ -20,7 +20,7 @@
   [httpd-component]
   (-> httpd-component
       rest-api-routes
-      ring/router
+      (ring/router {:data {:middleware [middleware/wrap-enforce-roles]}})
       (ring/ring-handler handler/fallback)
       (ring-defaults/wrap-defaults ring-defaults/api-defaults)
       (middleware/wrap-cors)))

--- a/src/cmr/opendap/rest/app.clj
+++ b/src/cmr/opendap/rest/app.clj
@@ -20,7 +20,7 @@
   [httpd-component]
   (-> httpd-component
       rest-api-routes
-      (ring/router (middleware/reitit-enforce-roles httpd-component))
+      (ring/router (middleware/reitit-acls httpd-component))
       (ring/ring-handler handler/fallback)
       (ring-defaults/wrap-defaults ring-defaults/api-defaults)
       (middleware/wrap-cors)))

--- a/src/cmr/opendap/rest/handler/collection.clj
+++ b/src/cmr/opendap/rest/handler/collection.clj
@@ -4,7 +4,7 @@
    [clojure.java.io :as io]
    ;; XXX implement the OUS collection business logic
    ;; [cmr.opendap.ous.collection :as collection]
-   [cmr.opendap.rest.response :as response]
+   [cmr.opendap.http.response :as response]
    [taoensso.timbre :as log]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/cmr/opendap/rest/handler/core.clj
+++ b/src/cmr/opendap/rest/handler/core.clj
@@ -14,7 +14,7 @@
    [clojure.java.io :as io]
    [clojusc.twig :as twig]
    [cmr.opendap.health :as health]
-   [cmr.opendap.rest.response :as response]
+   [cmr.opendap.http.response :as response]
    [ring.middleware.file :as file-middleware]
    [ring.util.codec :as codec]
    [taoensso.timbre :as log]))

--- a/src/cmr/opendap/rest/middleware.clj
+++ b/src/cmr/opendap/rest/middleware.clj
@@ -2,6 +2,7 @@
   "Custom ring middleware for CMR Graph."
   (:require
    [cmr.opendap.auth.permissions :as permissions]
+   [cmr.opendap.auth.roles :as roles]
    [cmr.opendap.auth.token :as token]
    [cmr.opendap.components.caching :as caching]
    [cmr.opendap.components.config :as config]
@@ -10,33 +11,47 @@
    [taoensso.timbre :as log]))
 
 (defn wrap-cors
+  "Ring-based middleware for supporting CORS requests."
   [handler]
   (fn [request]
     (response/cors request (handler request))))
 
-(defn wrap-enforce-roles
+(defn wrap-acls
+  "Ring-based middleware for supporting the protection of routes using the CMR
+  Access Control service and CMR Legacy ECHO support.
+
+  In particular, this wrapper allows for the protection of routes by both roles
+  as well as concept-specific permissions. This is done by annotating the routes
+  per the means described in the reitit library's documentation."
   [handler system]
   (fn [request]
     (log/debug "Running perms middleware ...")
-    (let [roles (get-in (ring/get-match request) [:data :get :roles])
+    ;; XXX Before performing any GETs/POSTs against CMR Access Control or ECHO,
+    ;;     make sure that's actually necessary, only doing it in the event that
+    ;;     the route is annotated for permissions
+    (let [route-roles (roles/route-annotation request)
           cmr-base-url (config/cmr-base-url system)
           user-token (token/extract request)
           user-id (token/->cached-user system cmr-base-url user-token)]
       (log/trace "cmr-base-url:" cmr-base-url)
       (log/trace "user-token:" user-token)
       (log/trace "user-id:" user-id)
-      (log/debug "roles:" roles)
+      (log/debug "route-roles:" route-roles)
       ;; XXX For now, there is only the admin role in the CMR, so we'll just
       ;;     keep this specific to that, for now. Later, if more roles are
       ;;     used, we'll want to make this more generic ...
-      (if roles
-        (if (permissions/admin? system roles cmr-base-url user-token user-id)
-          (handler request)
-          (response/not-allowed
-            "You do not have permissions to access that resource."))
-        (handler request)))))
+      (cond route-roles
+            (if (roles/admin? system route-roles cmr-base-url user-token user-id)
+              (handler request)
+              (response/not-allowed
+                "You do not have permissions to access that resource."))
+            ;; XXX check for permissions-based route annotations
+            :else
+            (handler request)))))
 
-(defn reitit-enforce-roles
+(defn reitit-acls
   [system]
+  "This is an example of non-Ring-middleware, specific to reitit. For more
+  details, see the documentation for `wrap-acls`."
   {:data
-    {:middleware [#(wrap-enforce-roles % system)]}})
+    {:middleware [#(wrap-acls % system)]}})

--- a/src/cmr/opendap/rest/middleware.clj
+++ b/src/cmr/opendap/rest/middleware.clj
@@ -25,7 +25,10 @@
 
 (defn reitit-auth
   [system]
-  "This auth middleware specific to reitit. For more details, see the docstring
-  above for `wrap-auth`."
+  "This auth middleware is specific to reitit, providing the data structure
+  necessary that will allow for the extraction of roles and permissions
+  settings from the request.
+
+  For more details, see the docstring above for `wrap-auth`."
   {:data
     {:middleware [#(wrap-auth % system)]}})

--- a/src/cmr/opendap/rest/middleware.clj
+++ b/src/cmr/opendap/rest/middleware.clj
@@ -1,10 +1,27 @@
 (ns cmr.opendap.rest.middleware
   "Custom ring middleware for CMR Graph."
   (:require
+   [clojure.set :as set]
    [cmr.opendap.rest.response :as response]
+   [reitit.ring :as ring]
    [taoensso.timbre :as log]))
 
 (defn wrap-cors
   [handler]
   (fn [request]
     (response/cors request (handler request))))
+
+(defn wrap-enforce-roles
+  [handler]
+  (fn [{:keys [::roles] :as request}]
+    (println "Running perms middleware ...")
+    (println "request:" request)
+    (let [required (some-> request (ring/get-match) :data :roles)]
+      (println "required:" required)
+      (println "get-match:" (ring/get-match request))
+      (println "data:" (:data (ring/get-match request)))
+      (println "data keys:" (keys (:data (ring/get-match request))))
+      (println "roles:" (:roles (:get (:data (ring/get-match request)))))
+      (if (and (seq required) (not (set/subset? required roles)))
+        {:status 403, :body "You do not have permissions to access that resource."}
+        (handler request)))))

--- a/src/cmr/opendap/rest/route.clj
+++ b/src/cmr/opendap/rest/route.clj
@@ -19,7 +19,15 @@
   [httpd-component]
   (let [conn-mgr :not-implemented]
     [["/opendap/ous/collections" {
-      :post (collection-handler/batch-generate conn-mgr)
+      :post {
+        :handler (collection-handler/batch-generate conn-mgr)
+        ;; XXX protecting collections will be a little different than
+        ;;     protecting a single collection, since the concept-id isn't in
+        ;;     the path-params. Instead, we'll have to parse the body, extract
+        ;;     the concepts ids from that, create an ACL query containing
+        ;;     multiple concept ids, and then check those results.
+        ;:permission #{...}
+        }
       :options core-handler/ok}]
      ["/opendap/ous/collection/:concept-id" {
       :get {

--- a/src/cmr/opendap/rest/route.clj
+++ b/src/cmr/opendap/rest/route.clj
@@ -43,13 +43,22 @@
 (defn admin
   [httpd-component]
   [["/health" {
-    :get {:handler (core-handler/health httpd-component)
-          :roles #{:admin}}
-    :options core-handler/ok}]
+    :get {
+      :handler (core-handler/health httpd-component)
+      :roles #{:admin}}
+    :options {
+      :handler core-handler/ok
+      :roles #{:admin}}}]
    ["/ping" {
-    :get core-handler/ping
-    :post core-handler/ping
-    :options core-handler/ok}]])
+    :get {
+      :handler core-handler/ping
+      :roles #{:admin}}
+    :post {
+      :handler core-handler/ping
+      :roles #{:admin}}
+    :options {
+      :handler core-handler/ok
+      :roles #{:admin}}}]])
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;   Testing Routes   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/cmr/opendap/rest/route.clj
+++ b/src/cmr/opendap/rest/route.clj
@@ -5,8 +5,6 @@
   handed off to the relevant request handler function."
   (:require
    [cmr.opendap.components.config :as config]
-   ;; XXX create connection pool manager component
-   ;; [cmr.opendap.components.httpc :as httpc]
    [cmr.opendap.health :as health]
    [cmr.opendap.rest.handler.collection :as collection-handler]
    [cmr.opendap.rest.handler.core :as core-handler]
@@ -19,7 +17,6 @@
 
 (defn ous
   [httpd-component]
-  ;; (let [conn-mgr (httpc/get-connection-manager httpd-component)]
   (let [conn-mgr :not-implemented]
     [["/opendap/ous/collections" {
       :post (collection-handler/batch-generate conn-mgr)
@@ -46,7 +43,8 @@
 (defn admin
   [httpd-component]
   [["/health" {
-    :get (core-handler/health httpd-component)
+    :get {:handler (core-handler/health httpd-component)
+          :roles #{:admin}}
     :options core-handler/ok}]
    ["/ping" {
     :get core-handler/ping

--- a/src/cmr/opendap/rest/route.clj
+++ b/src/cmr/opendap/rest/route.clj
@@ -22,8 +22,12 @@
       :post (collection-handler/batch-generate conn-mgr)
       :options core-handler/ok}]
      ["/opendap/ous/collection/:concept-id" {
-      :get (collection-handler/generate-urls conn-mgr)
-      :post (collection-handler/generate-urls conn-mgr)
+      :get {
+        :handler (collection-handler/generate-urls conn-mgr)
+        :permissions #{:read}}
+      :post {
+        :handler (collection-handler/generate-urls conn-mgr)
+        :permissions #{:read}}
       :options core-handler/ok}]]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -43,10 +47,8 @@
 (defn admin
   [httpd-component]
   [["/health" {
-    :get {
-      :handler (core-handler/health httpd-component)}
-    :options {
-      :handler core-handler/ok}}]
+    :get (core-handler/health httpd-component)
+    :options core-handler/ok}]
    ["/ping" {
     :get {
       :handler core-handler/ping
@@ -54,9 +56,7 @@
     :post {
       :handler core-handler/ping
       :roles #{:admin}}
-    :options {
-      :handler core-handler/ok
-      :roles #{:admin}}}]])
+    :options core-handler/ok}]])
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;   Testing Routes   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/cmr/opendap/rest/route.clj
+++ b/src/cmr/opendap/rest/route.clj
@@ -44,11 +44,9 @@
   [httpd-component]
   [["/health" {
     :get {
-      :handler (core-handler/health httpd-component)
-      :roles #{:admin}}
+      :handler (core-handler/health httpd-component)}
     :options {
-      :handler core-handler/ok
-      :roles #{:admin}}}]
+      :handler core-handler/ok}}]
    ["/ping" {
     :get {
       :handler core-handler/ping

--- a/src/cmr/opendap/testing/system.clj
+++ b/src/cmr/opendap/testing/system.clj
@@ -5,7 +5,7 @@
     [cmr.opendap.components.config :as config]
     [cmr.opendap.components.testing]))
 
-;; Hide logging as much as possible before the system starts up, which shuld
+;; Hide logging as much as possible before the system starts up, which should
 ;; disable logging entirely for tests.
 (logger/set-level! '[] :fatal)
 

--- a/test/cmr/opendap/tests/integration/rest/app.clj
+++ b/test/cmr/opendap/tests/integration/rest/app.clj
@@ -1,6 +1,9 @@
-(ns ^{:integration true} cmr.opendap.tests.rest.app
+(ns ^:integration cmr.opendap.tests.integration.rest.app
   "Note: this namespace is exclusively for integration tests; all tests defined
-  here will use one or more integration test fixtures."
+  here will use one or more integration test fixtures.
+
+  Definition used for integration tests:
+  * https://en.wikipedia.org/wiki/Software_testing#Integration_testing"
   (:require
     [clj-http.client :as httpc]
     [clojure.test :refer :all]
@@ -11,17 +14,6 @@
 (use-fixtures :once test-system/with-system)
 
 (deftest admin-routes
-  (testing "ping routes ..."
-    (let [result (httpc/get (format "http://localhost:%s/ping"
-                                    (test-system/http-port))
-                            {:as :json})]
-      (is (= 200 (:status result)))
-      (is (= "pong" (get-in result [:body :result]))))
-    (let [result (httpc/post (format "http://localhost:%s/ping"
-                                     (test-system/http-port))
-                             {:as :json})]
-      (is (= 200 (:status result)))
-      (is (= "pong" (get-in result [:body :result])))))
   (testing "health route ..."
     (let [result (httpc/get (format "http://localhost:%s/health"
                                     (test-system/http-port))

--- a/test/cmr/opendap/tests/integration/rest/app.clj
+++ b/test/cmr/opendap/tests/integration/rest/app.clj
@@ -5,41 +5,41 @@
   Definition used for integration tests:
   * https://en.wikipedia.org/wiki/Software_testing#Integration_testing"
   (:require
-    [clj-http.client :as httpc]
-    [clojure.test :refer :all]
-    [cmr.opendap.testing.system :as test-system])
+   [cheshire.core :as json]
+   [clojure.test :refer :all]
+   [cmr.opendap.testing.system :as test-system]
+   [org.httpkit.client :as httpc])
   (:import
-    (clojure.lang ExceptionInfo)))
+   (clojure.lang ExceptionInfo)))
 
 (use-fixtures :once test-system/with-system)
 
 (deftest admin-routes
   (testing "health route ..."
-    (let [result (httpc/get (format "http://localhost:%s/health"
-                                    (test-system/http-port))
-                            {:as :json})]
+    (let [result @(httpc/get (format "http://localhost:%s/health"
+                                     (test-system/http-port)))]
       (is (= 200 (:status result)))
       (is (= {:config {:ok? true}
               :httpd {:ok? true}
               :logging {:ok? false}}
-             (:body result))))))
+             (json/parse-string (:body result) true))))))
 
 (deftest testing-routes
-  (is (thrown-with-msg? ExceptionInfo #"status 401"
-    (httpc/get (format "http://localhost:%s/testing/401"
-                       (test-system/http-port)))))
-  (is (thrown-with-msg? ExceptionInfo #"status 403"
-    (httpc/get (format "http://localhost:%s/testing/403"
-                       (test-system/http-port)))))
-  (is (thrown-with-msg? ExceptionInfo #"status 404"
-    (httpc/get (format "http://localhost:%s/testing/404"
-                       (test-system/http-port)))))
-  (is (thrown-with-msg? ExceptionInfo #"status 405"
-    (httpc/get (format "http://localhost:%s/testing/405"
-                       (test-system/http-port)))))
-  (is (thrown-with-msg? ExceptionInfo #"status 500"
-    (httpc/get (format "http://localhost:%s/testing/500"
-                       (test-system/http-port)))))
-  (is (thrown-with-msg? ExceptionInfo #"status 503"
-    (httpc/get (format "http://localhost:%s/testing/503"
-                       (test-system/http-port))))))
+  (is 401
+      (:status @(httpc/get (format "http://localhost:%s/testing/401"
+                                   (test-system/http-port)))))
+  (is 403
+      (:status @(httpc/get (format "http://localhost:%s/testing/403"
+                                   (test-system/http-port)))))
+  (is 404
+      (:status @(httpc/get (format "http://localhost:%s/testing/404"
+                                   (test-system/http-port)))))
+  (is 405
+      (:status @(httpc/get (format "http://localhost:%s/testing/405"
+                                   (test-system/http-port)))))
+  (is 500
+      (:status @(httpc/get (format "http://localhost:%s/testing/500"
+                                   (test-system/http-port)))))
+  (is 503
+      (:status @(httpc/get (format "http://localhost:%s/testing/503"
+                                   (test-system/http-port))))))

--- a/test/cmr/opendap/tests/integration/system.clj
+++ b/test/cmr/opendap/tests/integration/system.clj
@@ -1,4 +1,4 @@
-(ns ^{:integration true} cmr.opendap.tests.system
+(ns ^:integration cmr.opendap.tests.integration.system
   "Tests for ensuring the proper setup of a testing system.
 
   Note: this namespace is exclusively for integration tests; all tests defined

--- a/test/cmr/opendap/tests/system/rest/app.clj
+++ b/test/cmr/opendap/tests/system/rest/app.clj
@@ -5,9 +5,9 @@
   Definition used for system tests:
   * https://en.wikipedia.org/wiki/Software_testing#System_testing"
   (:require
-    [clj-http.client :as httpc]
     [clojure.test :refer :all]
-    [cmr.opendap.testing.system :as test-system])
+    [cmr.opendap.testing.system :as test-system]
+    [org.httpkit.client :as httpc]  )
   (:import
     (clojure.lang ExceptionInfo)))
 

--- a/test/cmr/opendap/tests/system/rest/app.clj
+++ b/test/cmr/opendap/tests/system/rest/app.clj
@@ -1,0 +1,29 @@
+(ns ^:system cmr.opendap.tests.system.rest.app
+  "Note: this namespace is exclusively for system tests; all tests defined
+  here will use one or more system test fixtures.
+
+  Definition used for system tests:
+  * https://en.wikipedia.org/wiki/Software_testing#System_testing"
+  (:require
+    [clj-http.client :as httpc]
+    [clojure.test :refer :all]
+    [cmr.opendap.testing.system :as test-system])
+  (:import
+    (clojure.lang ExceptionInfo)))
+
+(use-fixtures :once test-system/with-system)
+
+(deftest admin-routes
+  ;; XXX Move this to a system test and read creds from filesystem
+  ; (testing "ping routes ..."
+  ;   (let [result (httpc/get (format "http://localhost:%s/ping"
+  ;                                   (test-system/http-port))
+  ;                           {:as :json})]
+  ;     (is (= 200 (:status result)))
+  ;     (is (= "pong" (get-in result [:body :result]))))
+  ;   (let [result (httpc/post (format "http://localhost:%s/ping"
+  ;                                    (test-system/http-port))
+  ;                            {:as :json})]
+  ;     (is (= 200 (:status result)))
+  ;     (is (= "pong" (get-in result [:body :result])))))
+  )

--- a/test/cmr/opendap/tests/unit/const.clj
+++ b/test/cmr/opendap/tests/unit/const.clj
@@ -1,0 +1,9 @@
+(ns cmr.opendap.tests.unit.const
+  "Note: this namespace is exclusively for unit tests."
+  (:require
+    [clojure.test :refer :all]
+    [cmr.opendap.const :as const]))
+
+(deftest user-agent
+  (is (= "CMR OPeNDAP Service/1.0 (+https://github.com/cmr-exchange/cmr-opendap)"
+         const/user-agent)))


### PR DESCRIPTION
This is a fairly large chunk of code that integrates CMR Access Control, Legacy ECHO, and CMR OPeNDAP in order to ensure that only those who have read rights to a collection can generate the OPeNDAP URLs for the given collection.

Note that this is a WIP and more commits are forthcoming ...