### PR TITLE
Feature: Handle parameter parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ $ lein ltest :unit
 Similarly, for just the integration tests:
 
 ```
-$ lein ltest :integration
+$ CMR_SIT_TOKEN=`cat ~/.cmr/tokens/sit` lein ltest :integration
 ```
 
 Just system tests:

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 
 * [About](#about-)
 * [Dependencies](#dependencies-)
+* [Configuration](#configuration-)
 * [Running the Tests](#running-the-tests-)
 * [Documentation](#documentation-)
   * [Quick Start](#quick-start-)
@@ -26,6 +27,18 @@ TBD
 
 * Java
 * `lein`
+
+
+## Configuration [&#x219F;](#contents)
+
+cmr-opendap is configured in several ways:
+
+* Low-level, component-based configuration: this is done with the file
+  `resources/config/cmr-opendap/config.edn`
+* Sensitive authorization information, in particular, tokens: these are
+  expected to be in `~/.cmr/tokens/sit`, `~/.cmr/tokens/uat`, and
+  `~/.cmr/tokens/prod` (no data structure; just the token value itself)
+* Environment variables: these are used for deployment.
 
 
 ## Running the Tests [&#x219F;](#contents)

--- a/src/cmr/opendap/ous/collection.clj
+++ b/src/cmr/opendap/ous/collection.clj
@@ -1,6 +1,116 @@
-(ns cmr.opendap.ous.collection)
+(ns cmr.opendap.ous.collection
+  (:require
+   [clojure.set :as set]))
 
-(defrecord CollectionParams [])
+;;; We're going to codify parameters with records to keep things well
+;;; documented. Additionally, this will make converting between parameter
+;;; schemes an explicit operation on explicit data.
+
+;; Notes on representing spatial extents.
+;;
+;; EDSC uses URL-encoded long/lat numbers representing a bounding box
+;; Note that the ordering is the same as that used by CMR (see below).
+;;  `-9.984375%2C56.109375%2C19.828125%2C67.640625`
+;; which URL-decodes to:
+;;  `-9.984375,56.109375,19.828125,67.640625`
+;;
+;; OPeNDAP download URLs have something I haven't figured out yet; given that
+;; one of the numbers if over 180, it can't be degrees ... it might be what
+;; WCS uses for `x` and `y`?
+;;  `Latitude[22:34],Longitude[169:200]`
+;;
+;; The OUS Prototype uses the WCS standard for lat/long:
+;;  `SUBSET=axis[,crs](low,high)`
+;; For lat/long this takes the following form:
+;;  `subset=lat(56.109375,67.640625)&subset=lon(-9.984375,19.828125)`
+;;
+;; CMR supports bounding spatial extents by describing a rectangle using four
+;; comma-separated values:
+;;  1. lower left longitude
+;;  2. lower left latitude
+;;  3. upper right longitude
+;;  4. upper right latitude
+;; For example:
+;;  `bounding_box==-9.984375,56.109375,19.828125,67.640625`
+;;
+;; Google's APIs use lower left, upper right, but the specify lat first, then
+;; long:
+;;  `southWest = LatLng(56.109375,-9.984375);`
+;;  `northEast = LatLng(67.640625,19.828125);`
+
+(defrecord OusPrototypeParams
+  [;; `format` is any of the formats supported by the target OPeNDAP server,
+   ;; such as `json`, `ascii`, `nc`, `nc4`, `dods`, etc.
+   format
+   ;; `coverage` can be:
+   ;;  * a list of granule concept ids
+   ;;  * a list of granule ccontept ids + a collection id
+   ;;  * a single collection id
+   coverage
+   ;; `rangesubset` is a list of comma-separated UMM-Var names
+   rangesubset
+   ;; `subset` is used to indicate desired spatial subsetting and is used in
+   ;; URL queries like so:
+   ;;  `?subset=lat(22,34)&subset=lon(169,200)`
+   subset])
+
+(defrecord CollectionParams
+  [;; `collection-id` is the concept id for the collection in question. Note
+   ;; that the collection concept id is not provided in query params,
+   ;; but in the path as part of the REST URL. Regardless, we offer it here as
+   ;; a record field.
+   collection-id
+   ;;
+   ;; `format` is any of the formats supported by the target OPeNDAP server,
+   ;; such as `json`, `ascii`, `nc`, `nc4`, `dods`, etc.
+   format
+   ;; `granules` is list of granule concept ids; default behaviour is a
+   ;; whitelist.
+   granules
+   ;; `exclude-granules?` is a boolean when set to true causes granules list
+   ;; to be a blacklist.
+   exclude-granules?
+   ;; `variables` is a list of variables to be speficied when creating the
+   ;; OPeNDAP URL. This is used for subsetting.
+   variables
+   ;; `spatial-subset` is used the same way as `subset` for WCS.
+   ;; `subset` is used to indicate desired spatial subsetting and is used in
+   ;; URL queries like so:
+   ;;  `?subset=lat(22,34)&subset=lon(169,200)`
+   subset])
+
+(defrecord CollectionsParams
+  [;; This isn't defined for the OUS Prototype, since it didn't support
+   ;; submitting multiple collections at a time. As such, there is no
+   ;; prototype-oriented record for this.
+   ;;
+   ;; `collections` is a list of `CollectionParams` records.
+   collections])
+
+(def shared-keys
+  #{:format :subset})
+
+(def ous-prototype-params-keys
+  (set/difference
+   (set (keys (map->OusPrototypeParams {})))
+   shared-keys))
+
+(def collection-params-keys
+  (set/difference
+   (set (keys (map->CollectionParams {})))
+   shared-keys))
+
+(defn ous-prototype-params?
+  [params]
+  (seq (set/intersection
+        (set (keys params))
+        ous-prototype-params-keys)))
+
+(defn collection-params?
+  [params]
+  (seq (set/intersection
+        (set (keys params))
+        collection-params-keys)))
 
 (defn get-opendap-urls
   []

--- a/src/cmr/opendap/ous/collection.clj
+++ b/src/cmr/opendap/ous/collection.clj
@@ -77,7 +77,10 @@
    ;; `subset` is used to indicate desired spatial subsetting and is used in
    ;; URL queries like so:
    ;;  `?subset=lat(22,34)&subset=lon(169,200)`
-   subset])
+   subset
+   ;; `bounding-box` is provided for CMR/EDSC-compatibility as an alternative
+   ;; to using `subset` for spatial-subsetting.
+   bounding-box])
 
 (defrecord CollectionsParams
   [;; This isn't defined for the OUS Prototype, since it didn't support
@@ -113,5 +116,9 @@
         collection-params-keys)))
 
 (defn get-opendap-urls
-  []
-  )
+  [params]
+  (cond (collection-params? params)
+        (map->CollectionParams params)
+        (ous-prototype-params? params)
+        (map->OusPrototypeParams params)
+        :else {:error :unsupported-parameters}))

--- a/src/cmr/opendap/ous/collection.clj
+++ b/src/cmr/opendap/ous/collection.clj
@@ -69,7 +69,7 @@
    granules
    ;; `exclude-granules?` is a boolean when set to true causes granules list
    ;; to be a blacklist.
-   exclude-granules?
+   exclude-granules
    ;; `variables` is a list of variables to be speficied when creating the
    ;; OPeNDAP URL. This is used for subsetting.
    variables

--- a/src/cmr/opendap/rest/handler/collection.clj
+++ b/src/cmr/opendap/rest/handler/collection.clj
@@ -12,27 +12,21 @@
 
 (defn- generate-via-get
   "XXX"
-  [conn-mgr request concept-id]
-  (->> [:params :q]
-       (get-in request)
-       ;; XXX maybe for params we should pass a populated record,
-       ;;     essentially using an API for params expected when
-       ;;     generating OPeNDAP URLs ... the record should probably be
-       ;;     in cmr.opendap.ous.collection and named something ...
-       ;;     OPeNDAPGenURLsParams seems rather horrific; we can pass a
-       ;;     map here in params and use that with the map->Record fn ...
-       ;(collections/get-opendap-urls conn-mgr params)
-       ((fn [_] {:error :not-implemented}))
+  [request concept-id]
+  (->> request
+       :params
+       (merge {:collection-id concept-id})
+       (collection/get-opendap-urls)
        (response/json request)))
 
 (defn- generate-via-post
   "XXX"
-  [conn-mgr request concept-id]
+  [request concept-id]
   (->> request
        :body
        slurp
        ;; XXX see note about params above, in sister function
-       ;(collections/get-opendap-urls conn-mgr params)
+       ;(collection/get-opendap-urls conn-mgr params)
        ((fn [_] {:error :not-implemented}))
        (response/json request)))
 
@@ -42,19 +36,17 @@
   ;; XXX add error message; utilize error reporting infra
   {:error :not-implemented})
 
-(defn generate-urls
+(def generate-urls
   "XXX"
-  [conn-mgr]
   (fn [request]
     (let [concept-id (get-in request [:path-params :concept-id])]
       (case (:method request)
-        :get (generate-via-get conn-mgr request concept-id)
-        :post (generate-via-post conn-mgr request concept-id)
+        :get (generate-via-get request concept-id)
+        :post (generate-via-post request concept-id)
         (unsupported-method request)))))
 
-(defn batch-generate
+(def batch-generate
   "XXX"
-  [conn-mgr]
   ;; XXX how much can we minimize round-tripping here?
   ;;     this may require creating divergent logic/impls ...
   (fn [request]

--- a/src/cmr/opendap/rest/handler/collection.clj
+++ b/src/cmr/opendap/rest/handler/collection.clj
@@ -11,8 +11,10 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn- generate-via-get
-  "XXX"
+  "Private function for creating OPeNDAP URLs when supplied with an HTTP
+  GET."
   [request concept-id]
+  (log/debug "Generating URLs based on HTTP GET ...")
   (->> request
        :params
        (merge {:collection-id concept-id})
@@ -20,7 +22,8 @@
        (response/json request)))
 
 (defn- generate-via-post
-  "XXX"
+  "Private function for creating OPeNDAP URLs when supplied with an HTTP
+  POST."
   [request concept-id]
   (->> request
        :body
@@ -39,8 +42,10 @@
 (def generate-urls
   "XXX"
   (fn [request]
+    (log/debug "Method-dispatching for URLs generation ...")
+    (log/trace "request:" request)
     (let [concept-id (get-in request [:path-params :concept-id])]
-      (case (:method request)
+      (case (:request-method request)
         :get (generate-via-get request concept-id)
         :post (generate-via-post request concept-id)
         (unsupported-method request)))))

--- a/src/cmr/opendap/rest/handler/collection.clj
+++ b/src/cmr/opendap/rest/handler/collection.clj
@@ -1,6 +1,7 @@
 (ns cmr.opendap.rest.handler.collection
   "This namespace defines the REST API handlers for collection resources."
   (:require
+   [cheshire.core :as json]
    [clojure.java.io :as io]
    [cmr.opendap.ous.collection :as collection]
    [cmr.opendap.http.response :as response]
@@ -27,10 +28,10 @@
   [request concept-id]
   (->> request
        :body
-       slurp
-       ;; XXX see note about params above, in sister function
-       ;(collection/get-opendap-urls conn-mgr params)
-       ((fn [_] {:error :not-implemented}))
+       (slurp)
+       (#(json/parse-string % true))
+       (merge {:collection-id concept-id})
+       (collection/get-opendap-urls)
        (response/json request)))
 
 (defn unsupported-method

--- a/src/cmr/opendap/rest/route.clj
+++ b/src/cmr/opendap/rest/route.clj
@@ -17,26 +17,25 @@
 
 (defn ous
   [httpd-component]
-  (let [conn-mgr :not-implemented]
-    [["/opendap/ous/collections" {
-      :post {
-        :handler (collection-handler/batch-generate conn-mgr)
-        ;; XXX protecting collections will be a little different than
-        ;;     protecting a single collection, since the concept-id isn't in
-        ;;     the path-params. Instead, we'll have to parse the body, extract
-        ;;     the concepts ids from that, create an ACL query containing
-        ;;     multiple concept ids, and then check those results.
-        ;:permission #{...}
-        }
-      :options core-handler/ok}]
-     ["/opendap/ous/collection/:concept-id" {
-      :get {
-        :handler (collection-handler/generate-urls conn-mgr)
-        :permissions #{:read}}
-      :post {
-        :handler (collection-handler/generate-urls conn-mgr)
-        :permissions #{:read}}
-      :options core-handler/ok}]]))
+  [["/opendap/ous/collections" {
+    :post {
+      :handler collection-handler/batch-generate
+      ;; XXX protecting collections will be a little different than
+      ;;     protecting a single collection, since the concept-id isn't in
+      ;;     the path-params. Instead, we'll have to parse the body, extract
+      ;;     the concepts ids from that, create an ACL query containing
+      ;;     multiple concept ids, and then check those results.
+      ;:permission #{...}
+      }
+    :options core-handler/ok}]
+   ["/opendap/ous/collection/:concept-id" {
+    :get {
+      :handler collection-handler/generate-urls
+      :permissions #{:read}}
+    :post {
+      :handler collection-handler/generate-urls
+      :permissions #{:read}}
+    :options core-handler/ok}]])
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;   Static Routes   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/cmr/opendap/testing/util.clj
+++ b/src/cmr/opendap/testing/util.clj
@@ -1,0 +1,23 @@
+(ns cmr.opendap.testing.util
+  (:require
+   [cheshire.core :as json]
+   [clojure.string :as string])
+  (:import
+   (clojure.lang Keyword)))
+
+(defn parse-response
+  [response]
+  (try
+    (json/parse-string (:body response) true)
+    (catch Exception e
+      {:error {:msg "Couldn't parse body."
+               :body (:body response)}})))
+
+(defn get-env-token
+  [^Keyword deployment]
+  (System/getenv (format "CMR_%s_TOKEN"
+                         (string/upper-case (name deployment)))))
+
+(def get-sit-token #(get-env-token :sit))
+(def get-uat-token #(get-env-token :uat))
+(def get-prod-token #(get-env-token :prod))

--- a/src/cmr/opendap/testing/util.clj
+++ b/src/cmr/opendap/testing/util.clj
@@ -1,6 +1,7 @@
 (ns cmr.opendap.testing.util
   (:require
    [cheshire.core :as json]
+   [clojure.java.io :as io]
    [clojure.string :as string])
   (:import
    (clojure.lang Keyword)))
@@ -12,6 +13,17 @@
     (catch Exception e
       {:error {:msg "Couldn't parse body."
                :body (:body response)}})))
+
+(defn create-json-payload
+  [data]
+  {:body (json/generate-string data)})
+
+(defn create-json-stream-payload
+  [data]
+  {:body (io/input-stream
+          (byte-array
+           (map (comp byte int)
+            (json/generate-string data))))})
 
 (defn get-env-token
   [^Keyword deployment]

--- a/test/cmr/opendap/tests/integration/rest/app.clj
+++ b/test/cmr/opendap/tests/integration/rest/app.clj
@@ -2,6 +2,13 @@
   "Note: this namespace is exclusively for integration tests; all tests defined
   here will use one or more integration test fixtures.
 
+  Warning: To run the integration tests, you will need to create CMR/ECHO
+  tokens and export these as shell environment variables. In particular, each
+  token gets its own ENV var:
+  * CMR_SIT_TOKEN
+  * CMR_UAT_TOKEN
+  * CMR_PROD_TOKEN
+
   Definition used for integration tests:
   * https://en.wikipedia.org/wiki/Software_testing#Integration_testing"
   (:require
@@ -16,13 +23,19 @@
 
 (deftest admin-routes
   (testing "health route ..."
-    (let [result @(httpc/get (format "http://localhost:%s/health"
-                                     (test-system/http-port)))]
-      (is (= 200 (:status result)))
+    (let [response @(httpc/get (format "http://localhost:%s/health"
+                                       (test-system/http-port)))]
+      (is (= 200 (:status response)))
       (is (= {:config {:ok? true}
               :httpd {:ok? true}
               :logging {:ok? false}}
-             (json/parse-string (:body result) true))))))
+             (json/parse-string (:body response) true)))))
+  (testing "protected admin route ..."
+    (let [response @(httpc/get (format "http://localhost:%s/ping"
+                                       (test-system/http-port)))]
+      (is (= 403 (:status response)))
+      (is (= "An ECHO token is required to access this resource."
+             (:body response))))))
 
 (deftest testing-routes
   (is 401
@@ -42,4 +55,19 @@
                                    (test-system/http-port)))))
   (is 503
       (:status @(httpc/get (format "http://localhost:%s/testing/503"
+
                                    (test-system/http-port))))))
+
+(deftest ous-collection-get-without-token
+  "Note that when a token is not provided, the request doesn't make it past
+  the network boundaries of CMR OPeNDAP, as such this is an integration test.
+  With tokens, however, it does: those tests are system tests."
+  (testing "Minimal get"
+    (let [collection-id "C1200187767-EDF_OPS"
+          response @(httpc/get
+                     (format "http://localhost:%s/opendap/ous/collection/%s"
+                             (test-system/http-port)
+                             collection-id))]
+      (is (= 403 (:status response)))
+      (is (= "An ECHO token is required to access this resource."
+             (:body response))))))

--- a/test/cmr/opendap/tests/system/rest/app.clj
+++ b/test/cmr/opendap/tests/system/rest/app.clj
@@ -305,3 +305,59 @@
               :subset nil
               :bounding-box "-9.984375,56.109375,19.828125,67.640625"}
              (util/parse-response response))))))
+
+(deftest ous-collection-get-with-prototype-params
+  (testing "GET with coverage ..."
+    (let [collection-id "C1200187767-EDF_OPS"
+          response @(httpc/get
+                     (format (str "http://localhost:%s"
+                                  "/opendap/ous/collection/%s"
+                                  "?coverage=G1200187775-EDF_OPS,G1200245955-EDF_OPS,"
+                                  collection-id)
+                             (test-system/http-port)
+                             collection-id)
+                     (request/add-token-header {} (util/get-sit-token)))]
+      (is (= 200 (:status response)))
+      (is (= {:collection-id "C1200187767-EDF_OPS"
+              :format nil
+              :coverage "G1200187775-EDF_OPS,G1200245955-EDF_OPS,C1200187767-EDF_OPS"
+              :rangesubset nil
+              :subset nil}
+             (util/parse-response response)))))
+  (testing "GET with coverage and rangesubset ..."
+    (let [collection-id "C1200187767-EDF_OPS"
+          response @(httpc/get
+                     (format (str "http://localhost:%s"
+                                  "/opendap/ous/collection/%s"
+                                  "?coverage=G1200187775-EDF_OPS,G1200245955-EDF_OPS,"
+                                  collection-id
+                                  "&rangesubset=V1200241812-EDF_OPS,V1200241813-EDF_OPS")
+                             (test-system/http-port)
+                             collection-id)
+                     (request/add-token-header {} (util/get-sit-token)))]
+      (is (= 200 (:status response)))
+      (is (= {:collection-id "C1200187767-EDF_OPS"
+              :format nil
+              :coverage "G1200187775-EDF_OPS,G1200245955-EDF_OPS,C1200187767-EDF_OPS"
+              :rangesubset "V1200241812-EDF_OPS,V1200241813-EDF_OPS"
+              :subset nil}
+             (util/parse-response response)))))
+  (testing "GET with coverage and subset ..."
+    (let [collection-id "C1200187767-EDF_OPS"
+          response @(httpc/get
+                     (format (str "http://localhost:%s"
+                                  "/opendap/ous/collection/%s"
+                                  "?coverage=G1200187775-EDF_OPS,G1200245955-EDF_OPS,"
+                                  collection-id
+                                  "&subset=lat(56.109375,67.640625)"
+                                  "&subset=lon(-9.984375,19.828125)")
+                             (test-system/http-port)
+                             collection-id)
+                     (request/add-token-header {} (util/get-sit-token)))]
+      (is (= 200 (:status response)))
+      (is (= {:collection-id "C1200187767-EDF_OPS"
+              :format nil
+              :coverage "G1200187775-EDF_OPS,G1200245955-EDF_OPS,C1200187767-EDF_OPS"
+              :rangesubset nil
+              :subset ["lat(56.109375,67.640625)" "lon(-9.984375,19.828125)"]}
+             (util/parse-response response))))))

--- a/test/cmr/opendap/tests/system/rest/app.clj
+++ b/test/cmr/opendap/tests/system/rest/app.clj
@@ -43,9 +43,27 @@
       (is (= 200 (:status response)))
       (is (= {:collection-id "C1200187767-EDF_OPS"
               :format nil
-              :granules nil
+              :granules []
               :exclude-granules nil
-              :variables nil
+              :variables []
+              :subset nil
+              :bounding-box nil}
+             (util/parse-response response)))))
+  (testing "GET one variable ..."
+    (let [collection-id "C1200187767-EDF_OPS"
+          response @(httpc/get
+                     (format (str "http://localhost:%s"
+                                  "/opendap/ous/collection/%s"
+                                  "?variables=V1200241812-EDF_OPS")
+                             (test-system/http-port)
+                             collection-id)
+                     (request/add-token-header {} (util/get-sit-token)))]
+      (is (= 200 (:status response)))
+      (is (= {:collection-id "C1200187767-EDF_OPS"
+              :format nil
+              :granules []
+              :exclude-granules nil
+              :variables ["V1200241812-EDF_OPS"]
               :subset nil
               :bounding-box nil}
              (util/parse-response response)))))
@@ -61,9 +79,9 @@
       (is (= 200 (:status response)))
       (is (= {:collection-id "C1200187767-EDF_OPS"
               :format nil
-              :granules nil
+              :granules []
               :exclude-granules nil
-              :variables "V1200241812-EDF_OPS,V1200241813-EDF_OPS"
+              :variables ["V1200241812-EDF_OPS" "V1200241813-EDF_OPS"]
               :subset nil
               :bounding-box nil}
              (util/parse-response response)))))
@@ -79,9 +97,9 @@
       (is (= 200 (:status response)))
       (is (= {:collection-id "C1200187767-EDF_OPS"
               :format nil
-              :granules "G1200187775-EDF_OPS,G1200245955-EDF_OPS"
+              :granules ["G1200187775-EDF_OPS" "G1200245955-EDF_OPS"]
               :exclude-granules nil
-              :variables nil
+              :variables []
               :subset nil
               :bounding-box nil}
              (util/parse-response response)))))
@@ -98,9 +116,9 @@
       (is (= 200 (:status response)))
       (is (= {:collection-id "C1200187767-EDF_OPS"
               :format nil
-              :granules "G1200187775-EDF_OPS,G1200245955-EDF_OPS"
+              :granules ["G1200187775-EDF_OPS" "G1200245955-EDF_OPS"]
               :exclude-granules "true"
-              :variables nil
+              :variables []
               :subset nil
               :bounding-box nil}
              (util/parse-response response)))))
@@ -117,9 +135,9 @@
       (is (= 200 (:status response)))
       (is (= {:collection-id "C1200187767-EDF_OPS"
               :format nil
-              :granules nil
+              :granules []
               :exclude-granules nil
-              :variables nil
+              :variables []
               :subset ["lat(56.109375,67.640625)" "lon(-9.984375,19.828125)"]
               :bounding-box nil}
              (util/parse-response response)))))
@@ -136,9 +154,154 @@
       (is (= 200 (:status response)))
       (is (= {:collection-id "C1200187767-EDF_OPS"
               :format nil
-              :granules nil
+              :granules []
               :exclude-granules nil
-              :variables nil
+              :variables []
+              :subset nil
+              :bounding-box "-9.984375,56.109375,19.828125,67.640625"}
+             (util/parse-response response))))))
+
+(deftest ous-collection-post-with-collection-params
+  (testing "Minimal POST ..."
+    (let [collection-id "C1200187767-EDF_OPS"
+          response @(httpc/post
+                     (format "http://localhost:%s/opendap/ous/collection/%s"
+                             (test-system/http-port)
+                             collection-id)
+                     (merge
+                      (util/create-json-payload
+                       {})
+                      (request/add-token-header
+                       {} (util/get-sit-token))))]
+      (is (= 200 (:status response)))
+      (is (= {:collection-id "C1200187767-EDF_OPS"
+              :format nil
+              :granules []
+              :exclude-granules nil
+              :variables []
+              :subset nil
+              :bounding-box nil}
+             (util/parse-response response)))))
+  (testing "POST with one variable ..."
+    (let [collection-id "C1200187767-EDF_OPS"
+          response @(httpc/post
+                     (format "http://localhost:%s/opendap/ous/collection/%s"
+                             (test-system/http-port)
+                             collection-id)
+                     (merge
+                      (util/create-json-payload
+                       {:variables ["V1200241812-EDF_OPS"]})
+                       (request/add-token-header {} (util/get-sit-token))))]
+      (is (= 200 (:status response)))
+      (is (= {:collection-id "C1200187767-EDF_OPS"
+              :format nil
+              :granules []
+              :exclude-granules nil
+              :variables ["V1200241812-EDF_OPS"]
+              :subset nil
+              :bounding-box nil}
+             (util/parse-response response)))))
+  (testing "POST with variables ..."
+    (let [collection-id "C1200187767-EDF_OPS"
+          response @(httpc/post
+                     (format "http://localhost:%s/opendap/ous/collection/%s"
+                             (test-system/http-port)
+                             collection-id)
+                     (merge
+                      (util/create-json-payload
+                       {:variables ["V1200241812-EDF_OPS"
+                                    "V1200241813-EDF_OPS"]})
+                       (request/add-token-header {} (util/get-sit-token))))]
+      (is (= 200 (:status response)))
+      (is (= {:collection-id "C1200187767-EDF_OPS"
+              :format nil
+              :granules []
+              :exclude-granules nil
+              :variables ["V1200241812-EDF_OPS" "V1200241813-EDF_OPS"]
+              :subset nil
+              :bounding-box nil}
+             (util/parse-response response)))))
+  (testing "POST with granules ..."
+    (let [collection-id "C1200187767-EDF_OPS"
+          response @(httpc/post
+                     (format "http://localhost:%s/opendap/ous/collection/%s"
+                             (test-system/http-port)
+                             collection-id)
+                     (merge
+                      (util/create-json-payload
+                       {:granules ["G1200187775-EDF_OPS"
+                                   "G1200245955-EDF_OPS"]})
+                      (request/add-token-header
+                       {} (util/get-sit-token))))]
+      (is (= 200 (:status response)))
+      (is (= {:collection-id "C1200187767-EDF_OPS"
+              :format nil
+              :granules ["G1200187775-EDF_OPS" "G1200245955-EDF_OPS"]
+              :exclude-granules nil
+              :variables []
+              :subset nil
+              :bounding-box nil}
+             (util/parse-response response)))))
+  (testing "POST without granules ..."
+    (let [collection-id "C1200187767-EDF_OPS"
+          response @(httpc/post
+                     (format "http://localhost:%s/opendap/ous/collection/%s"
+                             (test-system/http-port)
+                             collection-id)
+                     (merge
+                      (util/create-json-payload
+                       {:granules ["G1200187775-EDF_OPS"
+                                   "G1200245955-EDF_OPS"]
+                        :exclude-granules "true"})
+                      (request/add-token-header
+                       {} (util/get-sit-token))))]
+      (is (= 200 (:status response)))
+      (is (= {:collection-id "C1200187767-EDF_OPS"
+              :format nil
+              :granules ["G1200187775-EDF_OPS" "G1200245955-EDF_OPS"]
+              :exclude-granules "true"
+              :variables []
+              :subset nil
+              :bounding-box nil}
+             (util/parse-response response)))))
+  (testing "POST with subset ..."
+    (let [collection-id "C1200187767-EDF_OPS"
+          response @(httpc/post
+                     (format "http://localhost:%s/opendap/ous/collection/%s"
+                             (test-system/http-port)
+                             collection-id)
+                     (merge
+                      (util/create-json-payload
+                       {:subset ["lat(56.109375,67.640625)"
+                                 "lon(-9.984375,19.828125)"]})
+                      (request/add-token-header
+                       {} (util/get-sit-token))))]
+      (is (= 200 (:status response)))
+      (is (= {:collection-id "C1200187767-EDF_OPS"
+              :format nil
+              :granules []
+              :exclude-granules nil
+              :variables []
+              :subset ["lat(56.109375,67.640625)" "lon(-9.984375,19.828125)"]
+              :bounding-box nil}
+             (util/parse-response response)))))
+  (testing "POST with bounding box ..."
+    (let [collection-id "C1200187767-EDF_OPS"
+          response @(httpc/post
+                     (format "http://localhost:%s/opendap/ous/collection/%s"
+                             (test-system/http-port)
+                             collection-id)
+                     (merge
+                      (util/create-json-payload
+                       {:bounding-box "-9.984375,56.109375,19.828125,67.640625"})
+                      (request/add-token-header
+                       {} (util/get-sit-token))))]
+      (is (= 200 (:status response)))
+      (is (= {:collection-id "C1200187767-EDF_OPS"
+              :format nil
+              :granules []
+              :exclude-granules nil
+              :variables []
               :subset nil
               :bounding-box "-9.984375,56.109375,19.828125,67.640625"}
              (util/parse-response response))))))

--- a/test/cmr/opendap/tests/system/rest/app.clj
+++ b/test/cmr/opendap/tests/system/rest/app.clj
@@ -6,24 +6,139 @@
   * https://en.wikipedia.org/wiki/Software_testing#System_testing"
   (:require
     [clojure.test :refer :all]
+    [cmr.opendap.http.request :as request]
     [cmr.opendap.testing.system :as test-system]
-    [org.httpkit.client :as httpc]  )
+    [cmr.opendap.testing.util :as util]
+    [org.httpkit.client :as httpc])
   (:import
     (clojure.lang ExceptionInfo)))
 
 (use-fixtures :once test-system/with-system)
 
 (deftest admin-routes
-  ;; XXX Move this to a system test and read creds from filesystem
-  ; (testing "ping routes ..."
-  ;   (let [result (httpc/get (format "http://localhost:%s/ping"
-  ;                                   (test-system/http-port))
-  ;                           {:as :json})]
-  ;     (is (= 200 (:status result)))
-  ;     (is (= "pong" (get-in result [:body :result]))))
-  ;   (let [result (httpc/post (format "http://localhost:%s/ping"
-  ;                                    (test-system/http-port))
-  ;                            {:as :json})]
-  ;     (is (= 200 (:status result)))
-  ;     (is (= "pong" (get-in result [:body :result])))))
-  )
+  (testing "ping routes ..."
+    (let [response @(httpc/get (format "http://localhost:%s/ping"
+                                       (test-system/http-port))
+                               (request/add-token-header
+                                {} (util/get-sit-token)))]
+      (is (= 200 (:status response)))
+      (is (= {:result "pong"}
+             (util/parse-response response))))
+    (let [response @(httpc/post (format "http://localhost:%s/ping"
+                                        (test-system/http-port))
+                                (request/add-token-header
+                                 {} (util/get-sit-token)))]
+      (is (= 200 (:status response)))
+      (is (= {:result "pong"}
+             (util/parse-response response))))))
+
+(deftest ous-collection-get-with-collection-params
+  (testing "Minimal GET ..."
+    (let [collection-id "C1200187767-EDF_OPS"
+          response @(httpc/get
+                     (format "http://localhost:%s/opendap/ous/collection/%s"
+                             (test-system/http-port)
+                             collection-id)
+                     (request/add-token-header {} (util/get-sit-token)))]
+      (is (= 200 (:status response)))
+      (is (= {:collection-id "C1200187767-EDF_OPS"
+              :format nil
+              :granules nil
+              :exclude-granules nil
+              :variables nil
+              :subset nil
+              :bounding-box nil}
+             (util/parse-response response)))))
+  (testing "GET with variables ..."
+    (let [collection-id "C1200187767-EDF_OPS"
+          response @(httpc/get
+                     (format (str "http://localhost:%s"
+                                  "/opendap/ous/collection/%s"
+                                  "?variables=V1200241812-EDF_OPS,V1200241813-EDF_OPS")
+                             (test-system/http-port)
+                             collection-id)
+                     (request/add-token-header {} (util/get-sit-token)))]
+      (is (= 200 (:status response)))
+      (is (= {:collection-id "C1200187767-EDF_OPS"
+              :format nil
+              :granules nil
+              :exclude-granules nil
+              :variables "V1200241812-EDF_OPS,V1200241813-EDF_OPS"
+              :subset nil
+              :bounding-box nil}
+             (util/parse-response response)))))
+  (testing "GET with granules ..."
+    (let [collection-id "C1200187767-EDF_OPS"
+          response @(httpc/get
+                     (format (str "http://localhost:%s"
+                                  "/opendap/ous/collection/%s"
+                                  "?granules=G1200187775-EDF_OPS,G1200245955-EDF_OPS")
+                             (test-system/http-port)
+                             collection-id)
+                     (request/add-token-header {} (util/get-sit-token)))]
+      (is (= 200 (:status response)))
+      (is (= {:collection-id "C1200187767-EDF_OPS"
+              :format nil
+              :granules "G1200187775-EDF_OPS,G1200245955-EDF_OPS"
+              :exclude-granules nil
+              :variables nil
+              :subset nil
+              :bounding-box nil}
+             (util/parse-response response)))))
+  (testing "GET without granules ..."
+    (let [collection-id "C1200187767-EDF_OPS"
+          response @(httpc/get
+                     (format (str "http://localhost:%s"
+                                  "/opendap/ous/collection/%s"
+                                  "?granules=G1200187775-EDF_OPS,G1200245955-EDF_OPS"
+                                  "&exclude-granules=true")
+                             (test-system/http-port)
+                             collection-id)
+                     (request/add-token-header {} (util/get-sit-token)))]
+      (is (= 200 (:status response)))
+      (is (= {:collection-id "C1200187767-EDF_OPS"
+              :format nil
+              :granules "G1200187775-EDF_OPS,G1200245955-EDF_OPS"
+              :exclude-granules "true"
+              :variables nil
+              :subset nil
+              :bounding-box nil}
+             (util/parse-response response)))))
+  (testing "GET with subset ..."
+    (let [collection-id "C1200187767-EDF_OPS"
+          response @(httpc/get
+                     (format (str "http://localhost:%s"
+                                  "/opendap/ous/collection/%s"
+                                  "?subset=lat(56.109375,67.640625)"
+                                  "&subset=lon(-9.984375,19.828125)")
+                             (test-system/http-port)
+                             collection-id)
+                     (request/add-token-header {} (util/get-sit-token)))]
+      (is (= 200 (:status response)))
+      (is (= {:collection-id "C1200187767-EDF_OPS"
+              :format nil
+              :granules nil
+              :exclude-granules nil
+              :variables nil
+              :subset ["lat(56.109375,67.640625)" "lon(-9.984375,19.828125)"]
+              :bounding-box nil}
+             (util/parse-response response)))))
+  (testing "GET with bounding box ..."
+    (let [collection-id "C1200187767-EDF_OPS"
+          response @(httpc/get
+                     (format (str "http://localhost:%s"
+                                  "/opendap/ous/collection/%s"
+                                  "?bounding-box="
+                                  "-9.984375,56.109375,19.828125,67.640625")
+                             (test-system/http-port)
+                             collection-id)
+                     (request/add-token-header {} (util/get-sit-token)))]
+      (is (= 200 (:status response)))
+      (is (= {:collection-id "C1200187767-EDF_OPS"
+              :format nil
+              :granules nil
+              :exclude-granules nil
+              :variables nil
+              :subset nil
+              :bounding-box "-9.984375,56.109375,19.828125,67.640625"}
+             (util/parse-response response))))))

--- a/test/cmr/opendap/tests/unit/ous/collection.clj
+++ b/test/cmr/opendap/tests/unit/ous/collection.clj
@@ -7,16 +7,42 @@
 (deftest params-keys
   (is (= #{:coverage :rangesubset}
          collection/ous-prototype-params-keys))
-  (is (= #{:exclude-granules :collection-id :variables :granules
-           :bounding-box}
+  (is (= #{:exclude-granules :variables :granules :bounding-box}
          collection/collection-params-keys)))
 
 (deftest params?
-  (is (collection/ous-prototype-params?
-       (collection/map->OusPrototypeParams {})))
-  (is (not (collection/ous-prototype-params?
-            (collection/map->CollectionParams {}))))
-  (is (not (collection/collection-params?
-            (collection/map->OusPrototypeParams {}))))
-  (is (collection/collection-params?
-       (collection/map->CollectionParams {}))))
+  (testing "For records ..."
+    (is (collection/ous-prototype-params?
+         (collection/map->OusPrototypeParams {})))
+    (is (not (collection/ous-prototype-params?
+              (collection/map->CollectionParams {}))))
+    (is (not (collection/collection-params?
+              (collection/map->OusPrototypeParams {}))))
+    (is (collection/collection-params?
+         (collection/map->CollectionParams {}))))
+  (testing "For collection-params URL query strings ..."
+    (is (collection/collection-params?
+         {:granules "G1200187775-EDF_OPS,G1200245955-EDF_OPS"}))
+    (is (collection/collection-params?
+         {:granules "G1200187775-EDF_OPS,G1200245955-EDF_OPS"
+          :subset ["lat(56.109375,67.640625)" "lon(-9.984375,19.828125)"]}))
+    (is (not
+         (collection/ous-prototype-params?
+          {:granules "G1200187775-EDF_OPS,G1200245955-EDF_OPS"})))
+    (is (not
+         (collection/ous-prototype-params?
+          {:granules "G1200187775-EDF_OPS,G1200245955-EDF_OPS"
+           :subset ["lat(56.109375,67.640625)" "lon(-9.984375,19.828125)"]}))))
+  (testing "For ous-prototype-params URL query strings ..."
+    (is (collection/ous-prototype-params?
+         {:coverage "G1200187775-EDF_OPS,G1200245955-EDF_OPS"}))
+    (is (collection/ous-prototype-params?
+         {:coverage "G1200187775-EDF_OPS,G1200245955-EDF_OPS"
+          :subset ["lat(56.109375,67.640625)" "lon(-9.984375,19.828125)"]}))
+    (is (not
+         (collection/collection-params?
+          {:coverage "G1200187775-EDF_OPS,G1200245955-EDF_OPS"})))
+    (is (not
+         (collection/collection-params?
+          {:coverage "G1200187775-EDF_OPS,G1200245955-EDF_OPS"
+           :subset ["lat(56.109375,67.640625)" "lon(-9.984375,19.828125)"]})))))

--- a/test/cmr/opendap/tests/unit/ous/collection.clj
+++ b/test/cmr/opendap/tests/unit/ous/collection.clj
@@ -1,0 +1,21 @@
+(ns cmr.opendap.tests.unit.ous.collection
+  "Note: this namespace is exclusively for unit tests."
+  (:require
+    [clojure.test :refer :all]
+    [cmr.opendap.ous.collection :as collection]))
+
+(deftest params-keys
+  (is (= #{:coverage :rangesubset}
+         collection/ous-prototype-params-keys))
+  (is (= #{:exclude-granules? :collection-id :variables :granules}
+         collection/collection-params-keys)))
+
+(deftest params?
+  (is (collection/ous-prototype-params?
+       (collection/map->OusPrototypeParams {})))
+  (is (not (collection/ous-prototype-params?
+            (collection/map->CollectionParams {}))))
+  (is (not (collection/collection-params?
+            (collection/map->OusPrototypeParams {}))))
+  (is (collection/collection-params?
+       (collection/map->CollectionParams {}))))

--- a/test/cmr/opendap/tests/unit/ous/collection.clj
+++ b/test/cmr/opendap/tests/unit/ous/collection.clj
@@ -7,7 +7,7 @@
 (deftest params-keys
   (is (= #{:coverage :rangesubset}
          collection/ous-prototype-params-keys))
-  (is (= #{:exclude-granules? :collection-id :variables :granules
+  (is (= #{:exclude-granules :collection-id :variables :granules
            :bounding-box}
          collection/collection-params-keys)))
 

--- a/test/cmr/opendap/tests/unit/ous/collection.clj
+++ b/test/cmr/opendap/tests/unit/ous/collection.clj
@@ -7,7 +7,8 @@
 (deftest params-keys
   (is (= #{:coverage :rangesubset}
          collection/ous-prototype-params-keys))
-  (is (= #{:exclude-granules? :collection-id :variables :granules}
+  (is (= #{:exclude-granules? :collection-id :variables :granules
+           :bounding-box}
          collection/collection-params-keys)))
 
 (deftest params?

--- a/test/cmr/opendap/tests/unit/rest/handler/collection.clj
+++ b/test/cmr/opendap/tests/unit/rest/handler/collection.clj
@@ -1,0 +1,34 @@
+(ns cmr.opendap.tests.unit.rest.handler.collection
+  "Note: this namespace is exclusively for unit tests."
+  (:require
+   [cheshire.core :as json]
+   [clojure.test :refer :all]
+   [cmr.opendap.rest.handler.collection :as collection]))
+
+(defn parse-response
+  [response]
+  (json/parse-string (:body response) true))
+
+(deftest generate-via-get
+  (let [pvt-func #'collection/generate-via-get
+        concept-id :C123-PROV]
+    (is (= {:collection-id "C123-PROV"
+            :format nil
+            :granules nil
+            :exclude-granules? nil
+            :variables nil
+            :subset nil
+            :bounding-box nil}
+           (parse-response (pvt-func {:query-params {}}
+                                     concept-id))))
+    (is (= {:collection-id "C123-PROV"
+            :format nil
+            :granules nil
+            :exclude-granules? nil
+            :variables ["V1-PROV" "V2-PROV"]
+            :subset ["lat(22,34)" "lon(169,200)"]
+            :bounding-box nil}
+           (parse-response (pvt-func {:query-params
+                                      {:variables ["V1-PROV" "V2-PROV"]
+                                       :subset ["lat(22,34)" "lon(169,200)"]}}
+                                     concept-id))))))

--- a/test/cmr/opendap/tests/unit/rest/handler/collection.clj
+++ b/test/cmr/opendap/tests/unit/rest/handler/collection.clj
@@ -1,6 +1,7 @@
 (ns cmr.opendap.tests.unit.rest.handler.collection
   "Note: this namespace is exclusively for unit tests."
   (:require
+   [cheshire.core :as json]
    [clojure.test :refer :all]
    [cmr.opendap.rest.handler.collection :as collection]
    [cmr.opendap.testing.util :as util]))
@@ -10,16 +11,16 @@
         concept-id :C123-PROV]
     (is (= {:collection-id "C123-PROV"
             :format nil
-            :granules nil
+            :granules []
             :exclude-granules nil
-            :variables nil
+            :variables []
             :subset nil
             :bounding-box nil}
            (util/parse-response
             (pvt-func {:params {}} concept-id))))
     (is (= {:collection-id "C123-PROV"
             :format nil
-            :granules nil
+            :granules []
             :exclude-granules nil
             :variables ["V1-PROV" "V2-PROV"]
             :subset ["lat(56.109375,67.640625)"
@@ -27,7 +28,34 @@
             :bounding-box nil}
            (util/parse-response
             (pvt-func {:params
-                       {:variables ["V1-PROV" "V2-PROV"]
+                       {:variables "V1-PROV,V2-PROV"
                         :subset ["lat(56.109375,67.640625)"
                                  "lon(-9.984375,19.828125)"]}}
+                      concept-id))))))
+
+(deftest generate-via-post
+  (let [pvt-func #'collection/generate-via-post
+        concept-id :C123-PROV]
+    (is (= {:collection-id "C123-PROV"
+            :format nil
+            :granules []
+            :exclude-granules nil
+            :variables []
+            :subset nil
+            :bounding-box nil}
+           (util/parse-response
+            (pvt-func (util/create-json-stream-payload {}) concept-id))))
+    (is (= {:collection-id "C123-PROV"
+            :format nil
+            :granules []
+            :exclude-granules nil
+            :variables ["V1-PROV" "V2-PROV"]
+            :subset ["lat(56.109375,67.640625)"
+                     "lon(-9.984375,19.828125)"]
+            :bounding-box nil}
+           (util/parse-response
+            (pvt-func (util/create-json-stream-payload
+                       {:variables "V1-PROV,V2-PROV"
+                        :subset ["lat(56.109375,67.640625)"
+                                 "lon(-9.984375,19.828125)"]})
                       concept-id))))))

--- a/test/cmr/opendap/tests/unit/rest/handler/collection.clj
+++ b/test/cmr/opendap/tests/unit/rest/handler/collection.clj
@@ -1,13 +1,9 @@
 (ns cmr.opendap.tests.unit.rest.handler.collection
   "Note: this namespace is exclusively for unit tests."
   (:require
-   [cheshire.core :as json]
    [clojure.test :refer :all]
-   [cmr.opendap.rest.handler.collection :as collection]))
-
-(defn parse-response
-  [response]
-  (json/parse-string (:body response) true))
+   [cmr.opendap.rest.handler.collection :as collection]
+   [cmr.opendap.testing.util :as util]))
 
 (deftest generate-via-get
   (let [pvt-func #'collection/generate-via-get
@@ -15,20 +11,23 @@
     (is (= {:collection-id "C123-PROV"
             :format nil
             :granules nil
-            :exclude-granules? nil
+            :exclude-granules nil
             :variables nil
             :subset nil
             :bounding-box nil}
-           (parse-response (pvt-func {:query-params {}}
-                                     concept-id))))
+           (util/parse-response
+            (pvt-func {:params {}} concept-id))))
     (is (= {:collection-id "C123-PROV"
             :format nil
             :granules nil
-            :exclude-granules? nil
+            :exclude-granules nil
             :variables ["V1-PROV" "V2-PROV"]
-            :subset ["lat(22,34)" "lon(169,200)"]
+            :subset ["lat(56.109375,67.640625)"
+                     "lon(-9.984375,19.828125)"]
             :bounding-box nil}
-           (parse-response (pvt-func {:query-params
-                                      {:variables ["V1-PROV" "V2-PROV"]
-                                       :subset ["lat(22,34)" "lon(169,200)"]}}
-                                     concept-id))))))
+           (util/parse-response
+            (pvt-func {:params
+                       {:variables ["V1-PROV" "V2-PROV"]
+                        :subset ["lat(56.109375,67.640625)"
+                                 "lon(-9.984375,19.828125)"]}}
+                      concept-id))))))


### PR DESCRIPTION
This PR adds support for the following data flow:
* resource request at `/opendap/ous/collection/:concept-id`
* generic dispatch handler routes request based on HTTP method used
* HTTP `GET` parses query parameters, converts to records, and calls out to `get-opendap-url`s (currently a no-op)
* HTTP `POST` parses JSON body, converts to records, and calls out to `get-opendap-urls` (currently a no-op)

This PR includes unit, integration, and system tests.