### PR TITLE
Task: Extract services config data and update host code

### DIFF
--- a/resources/config/cmr-opendap/config.edn
+++ b/resources/config/cmr-opendap/config.edn
@@ -11,7 +11,32 @@
  ;;     into searate configs for each of those; at that point, we'll be able
  ;;     to update the config loading in the config component.
  :cmr
-  {:base-url "https://cmr.sit.earthdata.nasa.gov"}
+  {:access
+  	{:control
+  	  {:protocol "https"
+  	   :host "cmr.sit.earthdata.nasa.gov"
+  	   :relative
+  	     {:root
+  	       {:url "/access-control"}}}}
+   :echo
+    {:rest
+      {:protocol "https"
+       :host "cmr.sit.earthdata.nasa.gov"
+       :relative
+         {:root
+           {:url "/access-control"}}}}
+   :opendap
+    {:protocol "https"
+     :host "cmr.sit.earthdata.nasa.gov"
+     :relative
+  	     {:root
+  	       {:url "/access-control"}}}
+   :search
+    {:protocol "https"
+     :host "cmr.sit.earthdata.nasa.gov"
+     :relative
+  	   {:root
+  	     {:url "/search"}}}}
  :httpd
   {:port 3012
    :docroot "public"}

--- a/resources/config/cmr-opendap/config.edn
+++ b/resources/config/cmr-opendap/config.edn
@@ -22,9 +22,7 @@
     {:rest
       {:protocol "https"
        :host "cmr.sit.earthdata.nasa.gov"
-       :relative
-         {:root
-           {:url "/access-control"}}}}
+       :context "/legacy-services/rest"}}
    :opendap
     {:protocol "https"
      :host "cmr.sit.earthdata.nasa.gov"

--- a/resources/config/cmr-opendap/config.edn
+++ b/resources/config/cmr-opendap/config.edn
@@ -28,7 +28,7 @@
      :host "cmr.sit.earthdata.nasa.gov"
      :relative
   	     {:root
-  	       {:url "/access-control"}}}
+  	       {:url "/opendap"}}}
    :search
     {:protocol "https"
      :host "cmr.sit.earthdata.nasa.gov"

--- a/src/cmr/opendap/auth/acls.clj
+++ b/src/cmr/opendap/auth/acls.clj
@@ -8,7 +8,7 @@
    [org.httpkit.client :as httpc]
    [taoensso.timbre :as log]))
 
-(def acl-resource "/access-control/permissions")
+(def permissions-resource "/permissions")
 
 (defn parse-response
   [data]
@@ -20,7 +20,7 @@
 
 (defn check-access
   [base-url token user-id acl-query]
-  (let [url (str base-url acl-resource)]
+  (let [url (str base-url permissions-resource)]
     (httpc/request (-> request/default-options
                        (request/options
                         :method :get

--- a/src/cmr/opendap/auth/roles.clj
+++ b/src/cmr/opendap/auth/roles.clj
@@ -3,6 +3,7 @@
    [clojure.set :as set]
    [cmr.opendap.auth.acls :as acls]
    [cmr.opendap.components.caching :as caching]
+   [cmr.opendap.components.config :as config]
    [reitit.ring :as ring]
    [taoensso.timbre :as log]))
 
@@ -38,12 +39,14 @@
     (cmr-acl->reitit-acl @perms)))
 
 (defn cached-admin
-  [system base-url token user-id]
+  [system token user-id]
   (caching/lookup system
                   (admin-key token)
-                  #(admin base-url token user-id)))
+                  #(admin (config/get-access-control-url system)
+                          token
+                          user-id)))
 
 (defn admin?
-  [system route-roles base-url token user-id]
-  (seq (set/intersection (cached-admin system base-url token user-id)
+  [system route-roles token user-id]
+  (seq (set/intersection (cached-admin system token user-id)
                          route-roles)))

--- a/src/cmr/opendap/auth/token.clj
+++ b/src/cmr/opendap/auth/token.clj
@@ -2,13 +2,14 @@
   (:require
    [clojure.data.xml :as xml]
    [cmr.opendap.components.caching :as caching]
+   [cmr.opendap.components.config :as config]
    [cmr.opendap.const :as const]
    [cmr.opendap.http.request :as request]
    [cmr.opendap.http.response :as response]
    [org.httpkit.client :as httpc]
    [taoensso.timbre :as log]))
 
-(def token-info-resource "/legacy-services/rest/tokens/get_token_info")
+(def token-info-resource "/tokens/get_token_info")
 
 (defn token-data-key
   [token]
@@ -48,8 +49,8 @@
   @(get-token-info base-url token))
 
 (defn ->cached-user
-  [system base-url token]
+  [system token]
   (caching/lookup
    system
    (user-id-key token)
-   #(->user base-url token)))
+   #(->user (config/get-echo-rest-url system) token)))

--- a/src/cmr/opendap/components/config.clj
+++ b/src/cmr/opendap/components/config.clj
@@ -41,9 +41,19 @@
   [system]
   (get-in (get-cfg system) [:caching :type]))
 
+(defn get-service
+  [system service]
+  (let [svc-cfg (get-in (get-cfg system)
+                        (concat [:cmr] (config/service-keys service)))]
+    svc-cfg))
+
 (defn cmr-base-url
   [system]
-  (get-in (get-cfg system) [:cmr :base-url]))
+  (config/service->base-url (get-service system :search)))
+
+(defn get-service-url
+  [system service]
+  (config/service->url (get-service system service)))
 
 (defn http-docroot
   [system]

--- a/src/cmr/opendap/components/config.clj
+++ b/src/cmr/opendap/components/config.clj
@@ -89,7 +89,7 @@
   (log/info "Starting config component ...")
   (log/debug "Started config component.")
   (let [cfg (config/data)]
-    (log/debug "Built configuration:" (into {} cfg))
+    (log/debug "Built configuration:" cfg)
     (assoc this :data cfg)))
 
 (defn stop

--- a/src/cmr/opendap/components/config.clj
+++ b/src/cmr/opendap/components/config.clj
@@ -55,6 +55,12 @@
   [system service]
   (config/service->url (get-service system service)))
 
+(def get-access-control-url #(get-service-url % :access-control))
+(def get-echo-rest-url #(get-service-url % :echo-rest))
+(def get-ingest-url #(get-service-url % :ingest))
+(def get-opendap-url #(get-service-url % :opendap))
+(def get-search-url #(get-service-url % :search))
+
 (defn http-docroot
   [system]
   (get-in (get-cfg system) [:httpd :docroot]))

--- a/src/cmr/opendap/config.clj
+++ b/src/cmr/opendap/config.clj
@@ -69,4 +69,6 @@
   [^Keyword service]
   (format "%s%s"
           (service->base-url service)
-          (or (get-in service [:relative :root :url]) "/")))
+          (or (get-in service [:relative :root :url])
+              (:context service)
+              "/")))

--- a/src/cmr/opendap/util.clj
+++ b/src/cmr/opendap/util.clj
@@ -1,0 +1,8 @@
+(ns cmr.opendap.util)
+
+(defn deep-merge
+  "Merge maps recursively."
+  [& maps]
+  (if (every? #(or (map? %) (nil? %)) maps)
+    (apply merge-with deep-merge maps)
+    (last maps)))

--- a/test/cmr/opendap/tests/unit/util.clj
+++ b/test/cmr/opendap/tests/unit/util.clj
@@ -1,0 +1,26 @@
+(ns cmr.opendap.tests.unit.util
+  "Note: this namespace is exclusively for unit tests."
+  (:require
+    [clojure.test :refer :all]
+    [cmr.opendap.util :as util]))
+
+(deftest deep-merge
+  (is (= {} (util/deep-merge {} {})))
+  (is (= {:a 2} (util/deep-merge {:a 1} {:a 2})))
+  (is (= {:a 1 :b 2} (util/deep-merge {:a 1} {:b 2})))
+  (is (= {:a 2} (util/deep-merge {:a {:b {:c {:d 1}}}} {:a 2})))
+  (is (= {:a {:b 2}} (util/deep-merge {:a {:b {:c {:d 1}}}} {:a {:b 2}})))
+  (is (= {:a {:b {:c {:d 1}}} :e 2}
+         (util/deep-merge {:a {:b {:c {:d 1}}}} {:e 2})))
+  (is (= {:a {:b {:c {:d 1}}
+              :e {:f {:g 1}}}}
+         (util/deep-merge {:a {:b {:c {:d 1}}}}
+                          {:a {:e {:f {:g 1}}}})))
+  (is (= {:a {:b {:c {:d 1}
+                  :e {:f 1}}}}
+         (util/deep-merge {:a {:b {:c {:d 1}}}}
+                          {:a {:b {:e {:f 1}}}})))
+  (is (= {:a {:b {:c {:d 1
+                      :e 1}}}}
+         (util/deep-merge {:a {:b {:c {:d 1}}}}
+                          {:a {:b {:c {:e 1}}}}))))


### PR DESCRIPTION
Now that we're deployed (on SIT), we're supporting ENV vars as passed to NGAP via EECS. This means we now know which env we're deployed into and no longer need fragile host references. All of this has been changed to depend upon configuration as it will be seen in deployment (with the local EDN config file getting updated to match).