### PR TITLE
Feature/define error payloads

### DIFF
--- a/dev-resources/src/cmr/opendap/dev.clj
+++ b/dev-resources/src/cmr/opendap/dev.clj
@@ -2,6 +2,7 @@
   "CMR OPeNDAP development namespace."
   (:require
     [cheshire.core :as json]
+    [clojure.data.xml :as xml]
     [clojure.java.io :as io]
     [clojure.pprint :refer [pprint]]
     [clojure.set :as set]
@@ -14,7 +15,8 @@
     [cmr.opendap.components.core]
     [com.stuartsierra.component :as component]
     [org.httpkit.client :as httpc]
-    [trifl.java :refer [show-methods]])
+    [trifl.java :refer [show-methods]]
+    [xml-in.core :as xml-in])
   (:import
     (java.net URI)
     (java.nio.file Paths)))

--- a/dev-resources/src/cmr/opendap/dev.clj
+++ b/dev-resources/src/cmr/opendap/dev.clj
@@ -1,6 +1,7 @@
 (ns cmr.opendap.dev
   "CMR OPeNDAP development namespace."
   (:require
+    [cheshire.core :as json]
     [clojure.java.io :as io]
     [clojure.pprint :refer [pprint]]
     [clojure.set :as set]

--- a/project.clj
+++ b/project.clj
@@ -39,7 +39,8 @@
     [ring/ring-core "1.6.3"]
     [ring/ring-codec "1.1.0"]
     [ring/ring-defaults "0.3.1"]
-    [selmer "1.11.7"]]
+    [selmer "1.11.7"]
+    [tolitius/xml-in "0.1.0"]]
   :jvm-opts ["-XX:-OmitStackTraceInFastThrow"
              "-Xms2g"
              "-Xmx2g"]

--- a/resources/docs/markdown/2000-usage.md
+++ b/resources/docs/markdown/2000-usage.md
@@ -8,7 +8,8 @@
   * Authorized Access
   * Collection Resource
   * Forthcoming
-* Miscellaneous Resources
+* Admin Resources
+  * Cache
   * Health
   * Ping
 
@@ -333,9 +334,22 @@ The following are coming soon:
 * `POST /opendap/ous/collections`
 
 
-## Miscellaneous Resources
+## Admin Resources
+
+### Cache
+
+Administrative users may use a token to access the following:
+
+* `GET    /opendap/cache`
+* `DELETE /opendap/cache`
+* `GET    /opendap/cache/:item-key`
+* `DELETE /opendap/cache/:item-key`
+
 
 ### Health
+
+Even though the `health` resources are classified as "admin", they are
+available for use by anyone.
 
 * `GET     /opendap/health`
 * `OPTIONS /opendap/health`

--- a/src/cmr/opendap/auth/permissions.clj
+++ b/src/cmr/opendap/auth/permissions.clj
@@ -75,12 +75,12 @@
   "Query the CMR Access Control API to get the permissions the given token+user
   have for the given concept."
   [base-url token user-id concept-id]
-  (let [perms (acls/check-access base-url
-                                 token
-                                 user-id
-                                 (echo-concept-query concept-id))]
-    (log/debug "Got perms:" @perms)
-    (cmr-acl->reitit-acl @perms)))
+  (let [perms @(acls/check-access base-url
+                                  token
+                                  user-id
+                                  (echo-concept-query concept-id))]
+    (log/debug "Got perms:" perms)
+    (cmr-acl->reitit-acl perms)))
 
 (defn cached-concept
   "Look up the permissions for a concept in the cache; if there is a miss,

--- a/src/cmr/opendap/auth/roles.clj
+++ b/src/cmr/opendap/auth/roles.clj
@@ -48,11 +48,12 @@
 (defn admin
   "Query the CMR Access Control API to get the roles for the given token+user."
   [base-url token user-id]
-  (let [perms (acls/check-access base-url
-                                 token
-                                 user-id
-                                 echo-management-query)]
-    (cmr-acl->reitit-acl @perms)))
+  (let [perms @(acls/check-access base-url
+                                  token
+                                  user-id
+                                  echo-management-query)]
+    (log/debug "Got permissions:" perms)
+    (cmr-acl->reitit-acl perms)))
 
 (defn cached-admin
   "Look up the roles for token+user in the cache; if there is a miss, make the

--- a/src/cmr/opendap/rest/handler/cache.clj
+++ b/src/cmr/opendap/rest/handler/cache.clj
@@ -1,0 +1,41 @@
+(ns cmr.opendap.rest.handler.cache
+  "This namespace defines the handlers for the cache REST API resources."
+  (:require
+   [clojure.java.io :as io]
+   [clojusc.twig :as twig]
+   [cmr.opendap.components.caching :as caching]
+   [cmr.opendap.http.response :as response]
+   [taoensso.timbre :as log]))
+
+(defn lookup-all
+  [component]
+  (fn [request]
+    (->> component
+         caching/lookup-all
+         (response/json request))))
+
+(defn evict-all
+  [component]
+  (fn [request]
+    (log/debug "Evicting all cached items ...")
+    (->> component
+         caching/evict-all
+         (response/json request))))
+
+(defn lookup
+  [component]
+  (fn [request]
+    (let [item-key (get-in request [:path-params :item-key])]
+      (response/json
+       request
+       (caching/lookup component item-key)))))
+
+(defn evict
+  [component]
+  (fn [request]
+    (let [item-key (get-in request [:path-params :item-key])]
+      (log/debugf "Evicting value cached at key %s ..." item-key)
+      (caching/evict component item-key)
+      (response/json
+       request
+       (caching/lookup component item-key)))))

--- a/src/cmr/opendap/rest/handler/core.clj
+++ b/src/cmr/opendap/rest/handler/core.clj
@@ -1,5 +1,5 @@
 (ns cmr.opendap.rest.handler.core
-  "This namespace defines the handlers for REST API resources.
+  "This namespace defines the handlers for general resources.
 
   Simple handlers will only need to make a call to a library and then have that
   data prepared for the client by standard response function. More complex

--- a/src/cmr/opendap/rest/route.clj
+++ b/src/cmr/opendap/rest/route.clj
@@ -6,6 +6,7 @@
   (:require
    [cmr.opendap.components.config :as config]
    [cmr.opendap.health :as health]
+   [cmr.opendap.rest.handler.cache :as cache-handler]
    [cmr.opendap.rest.handler.collection :as collection-handler]
    [cmr.opendap.rest.handler.core :as core-handler]
    [cmr.opendap.site.pages :as pages]
@@ -58,7 +59,17 @@
 
 (defn admin-api
   [httpd-component]
-  [["/opendap/health" {
+  [["/opendap/cache" {
+    :get {:handler (cache-handler/lookup-all httpd-component)
+          :roles #{:admin}}
+    :delete {:handler (cache-handler/evict-all httpd-component)
+             :roles #{:admin}}}]
+   ["/opendap/cache/:item-key" {
+    :get {:handler (cache-handler/lookup httpd-component)
+          :roles #{:admin}}
+    :delete {:handler (cache-handler/evict httpd-component)
+             :roles #{:admin}}}]
+   ["/opendap/health" {
     :get (core-handler/health httpd-component)
     :options core-handler/ok}]
    ["/opendap/ping" {

--- a/test/cmr/opendap/tests/integration/rest/app/admin.clj
+++ b/test/cmr/opendap/tests/integration/rest/app/admin.clj
@@ -14,6 +14,7 @@
   (:require
    [cheshire.core :as json]
    [clojure.test :refer :all]
+   [cmr.opendap.http.response :as response]
    [cmr.opendap.testing.system :as test-system]
    [org.httpkit.client :as httpc])
   (:import
@@ -34,8 +35,8 @@
     (let [response @(httpc/get (format "http://localhost:%s/opendap/ping"
                                        (test-system/http-port)))]
       (is (= 403 (:status response)))
-      (is (= "An ECHO token is required to access this resource."
-             (:body response))))))
+      (is (= {:errors ["An ECHO token is required to access this resource."]}
+             (response/parse-json-body (:body response)))))))
 
 (deftest testing-routes
   (is 401

--- a/test/cmr/opendap/tests/integration/rest/app/ous.clj
+++ b/test/cmr/opendap/tests/integration/rest/app/ous.clj
@@ -13,6 +13,7 @@
   * https://en.wikipedia.org/wiki/Software_testing#Integration_testing"
   (:require
    [clojure.test :refer :all]
+   [cmr.opendap.http.response :as response]
    [cmr.opendap.testing.system :as test-system]
    [org.httpkit.client :as httpc]))
 
@@ -29,5 +30,5 @@
                              (test-system/http-port)
                              collection-id))]
       (is (= 403 (:status response)))
-      (is (= "An ECHO token is required to access this resource."
-             (:body response))))))
+      (is (= {:errors ["An ECHO token is required to access this resource."]}
+             (response/parse-json-body (:body response)))))))

--- a/test/cmr/opendap/tests/unit/auth/token.clj
+++ b/test/cmr/opendap/tests/unit/auth/token.clj
@@ -1,0 +1,24 @@
+(ns cmr.opendap.tests.unit.auth.token
+  "Note: this namespace is exclusively for unit tests."
+  (:require
+    [clojure.test :refer :all]
+    [cmr.opendap.auth.token :as token]))
+
+(def xml-test-body
+  (str "<token_info>\n"
+       "  <token>deadbeef-cafe-244837814094590</token>\n"
+       "  <user_name>4l1c3</user_name>\n"
+       "  <expires type=\"datetime\">2018-06-07T10:54:13Z</expires>\n"
+       "  <guest type=\"boolean\">false</guest>\n"
+       "  <created type=\"datetime\">2018-05-08T10:54:13Z</created>\n"
+       "  <user_guid>abc-123</user_guid>\n"
+       "  <client_id>alice@nasa.gov</client_id>\n"
+       "</token_info>\n"))
+
+(deftest parse-token
+  (is (= ["deadbeef-cafe-244837814094590"]
+         (token/parse-token xml-test-body))))
+
+(deftest parse-username
+  (is (= ["4l1c3"]
+         (token/parse-username xml-test-body))))

--- a/test/cmr/opendap/tests/unit/http/response.clj
+++ b/test/cmr/opendap/tests/unit/http/response.clj
@@ -1,0 +1,31 @@
+(ns cmr.opendap.tests.unit.http.response
+  "Note: this namespace is exclusively for unit tests."
+  (:require
+    [clojure.test :refer :all]
+    [cmr.opendap.http.response :as response]
+    [xml-in.core :as xml-in]))
+
+(def xml-test-body
+  (str "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+       "<foo foo-attr=\"foo value\">\n"
+       "  <bar bar-attr=\"bar value\">\n"
+       "    <baz>The baz value1</baz>\n"
+       "    <baz>The baz value2</baz>\n"
+       "    <baz>The baz value3</baz>\n"
+       "   </bar>\n"
+       "</foo>\n"))
+
+(def xml-errprs
+  (str "<errors>\n"
+       "  <error>Hammer time</error>\n"
+       "  <error>Can't touch this</error>\n"
+       "</errors>\n"))
+
+(deftest parse-xml-body
+  (is (= ["The baz value1" "The baz value2" "The baz value3"]
+         (xml-in/find-all (response/parse-xml-body xml-test-body)
+                          [:foo :bar :baz]))))
+
+(deftest xml-errors
+  (is (= ["Hammer time" "Can't touch this"]
+         (response/xml-errors xml-errprs))))


### PR DESCRIPTION
Auth errors at the CMR Access Control service-level are no longer swallowed; instead, they are collected and passed up to the CMR OPeNDAP response.