### PR TITLE
Feature/streaming long calls

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -34,6 +34,7 @@
     [metosin/reitit-ring "0.1.1-SNAPSHOT"]
     [metosin/ring-http-response "0.9.0"]
     [org.clojure/clojure "1.9.0"]
+    [org.clojure/core.async "0.4.474"]
     [org.clojure/core.cache "0.7.1"]
     [org.clojure/data.xml "0.2.0-alpha5"]
     [ring/ring-core "1.6.3"]

--- a/resources/config/cmr-opendap/config.edn
+++ b/resources/config/cmr-opendap/config.edn
@@ -52,4 +52,8 @@
  :logging
   {:level :debug
    :nss [cmr.opendap org.httpkit]
-   :color false}}
+   :color false}
+ :streaming
+  {:timeout 20000 ; milliseconds 20 seconds * 1000
+   :heartbeat 200 ; milliseconds
+   }}

--- a/resources/docs/markdown/2000-usage.md
+++ b/resources/docs/markdown/2000-usage.md
@@ -147,7 +147,8 @@ curl -H "Echo-Token: `cat ~/.cmr/tokens/sit`" \
 
 ##### `exclude-granules`
 
-This allows clients to perform the inverse of a granule search: all granules
+This allows clients to perform the inverse of a granule search. If the
+value of this parameter is all granules
 _except_ the ones passed. Granules may either be pass
 
 If not provided, a regular granule search is performed.

--- a/src/cmr/opendap/auth/core.clj
+++ b/src/cmr/opendap/auth/core.clj
@@ -53,6 +53,7 @@
     (let [user-lookup (token/->cached-user system user-token)
           errors (:errors user-lookup)]
       (log/debug "ECHO token provided; proceeding ...")
+      (log/trace "user-lookup:" user-lookup)
       (if errors
         (response/not-allowed errors/token-required errors)
         (do

--- a/src/cmr/opendap/auth/permissions.clj
+++ b/src/cmr/opendap/auth/permissions.clj
@@ -62,14 +62,20 @@
   [request]
   (get-in request [:path-params :concept-id]))
 
+(defn- -route-annotation
+  [request]
+  (get-in (ring/get-match request) [:data :get :permissions]))
+
 (defn route-annotation
   "Extract any permissions annotated in the route associated with the given
   request."
   [request]
-  (reitit-acl-data
-   (route-concept-id request)
-   (cmr-acl->reitit-acl
-    (get-in (ring/get-match request) [:data :get :permissions]))))
+  (let [annotation (-route-annotation request)]
+    (log/debug "Permissions annotation:" annotation)
+    (when annotation
+      (reitit-acl-data
+       (route-concept-id request)
+       (cmr-acl->reitit-acl annotation)))))
 
 (defn concept
   "Query the CMR Access Control API to get the permissions the given token+user

--- a/src/cmr/opendap/components/config.clj
+++ b/src/cmr/opendap/components/config.clj
@@ -125,6 +125,14 @@
   [system]
   (get-in (get-cfg system) [:logging :nss]))
 
+(defn streaming-heartbeat
+  [system]
+  (get-in (get-cfg system) [:streaming :heartbeat]))
+
+(defn streaming-timeout
+  [system]
+  (get-in (get-cfg system) [:streaming :timeout]))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;   Component Lifecycle Implementation   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/cmr/opendap/http/response.clj
+++ b/src/cmr/opendap/http/response.clj
@@ -68,7 +68,10 @@
           (error-handler status headers body)
 
           :else
-          (parse-fn body))))
+          (do
+            (log/trace "headers:" headers)
+            (log/trace "body:" body)
+            (parse-fn body)))))
 
 (def json-handler #(client-handler % parse-json-body))
 

--- a/src/cmr/opendap/ous/collection/core.clj
+++ b/src/cmr/opendap/ous/collection/core.clj
@@ -24,11 +24,16 @@
          (request/add-accept "application/json"))
      response/json-handler)))
 
+(defn extract-metadata
+  [promise]
+  (let [results @promise]
+    (log/debug "Got results from CMR granule collection:" results)
+    (first (get-in results [:feed :entry]))))
+
 (defn get-metadata
   [search-endpoint user-token params]
-  (let [results @(async-get-metadata search-endpoint user-token params)]
-    (log/debug "Got results from CMR collection search:" results)
-    (first (get-in results [:feed :entry]))))
+  (let [promise (async-get-metadata search-endpoint user-token params)]
+    (extract-metadata promise)))
 
 (defn extract-variable-ids
   [entry]

--- a/src/cmr/opendap/ous/collection/core.clj
+++ b/src/cmr/opendap/ous/collection/core.clj
@@ -10,20 +10,25 @@
   [params]
   (str "concept_id=" (:collection-id params)))
 
-(defn get-metadata
+(defn async-get-metadata
   "Given a data structure with :collection-id, get the metadata for the
   associated collection."
   [search-endpoint user-token params]
   (let [url (str search-endpoint
                  "/collections?"
-                 (build-query params))
-        results (request/async-get url
-                 (-> {}
-                     (request/add-token-header user-token)
-                     (request/add-accept "application/json"))
-                 response/json-handler)]
+                 (build-query params))]
+    (request/async-get
+     url
+     (-> {}
+         (request/add-token-header user-token)
+         (request/add-accept "application/json"))
+     response/json-handler)))
+
+(defn get-metadata
+  [search-endpoint user-token params]
+  (let [results @(async-get-metadata search-endpoint user-token params)]
     (log/debug "Got results from CMR collection search:" results)
-    (first (get-in @results [:feed :entry]))))
+    (first (get-in results [:feed :entry]))))
 
 (defn extract-variable-ids
   [entry]

--- a/src/cmr/opendap/ous/core.clj
+++ b/src/cmr/opendap/ous/core.clj
@@ -12,50 +12,6 @@
    [taoensso.timbre :as log]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;;   Notes   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-;; General caveat: the logic for this code was translated -- without domain
-;; knowledge -- from Node.js code that was established as faulty and buggy.
-;; ALL OF THIS needs to be REASSESSED with an intelligent, knowledgable eye.
-
-;; Notes on representing spatial extents.
-;;
-;; EDSC uses URL-encoded long/lat numbers representing a bounding box
-;; Note that the ordering is the same as that used by CMR (see below).
-;;  `-9.984375%2C56.109375%2C19.828125%2C67.640625`
-;; which URL-decodes to:
-;;  `-9.984375,56.109375,19.828125,67.640625`
-;;
-;; OPeNDAP download URLs have something I haven't figured out yet; given that
-;; one of the numbers if over 180, it can't be degrees ... it might be what
-;; WCS uses for `x` and `y`?
-;;  `Latitude[22:34],Longitude[169:200]`
-;;
-;; The OUS Prototype uses the WCS standard for lat/long:
-;;  `SUBSET=axis[,crs](low,high)`
-;; For lat/long this takes the following form:
-;;  `subset=lat(56.109375,67.640625)&subset=lon(-9.984375,19.828125)`
-;;
-;; CMR supports bounding spatial extents by describing a rectangle using four
-;; comma-separated values:
-;;  1. lower left longitude
-;;  2. lower left latitude
-;;  3. upper right longitude
-;;  4. upper right latitude
-;; For example:
-;;  `bounding_box==-9.984375,56.109375,19.828125,67.640625`
-;;
-;; Google's APIs use lower left, upper right, but the specify lat first, then
-;; long:
-;;  `southWest = LatLng(56.109375,-9.984375);`
-;;  `northEast = LatLng(67.640625,19.828125);`
-
-;;; We're going to codify parameters with records to keep things well
-;;; documented. Additionally, this will make converting between parameter
-;;; schemes an explicit operation on explicit data.
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;   Utility/Support Functions   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/src/cmr/opendap/ous/granule.clj
+++ b/src/cmr/opendap/ous/granule.clj
@@ -63,11 +63,16 @@
          (request/add-accept "application/json"))
      response/json-handler)))
 
-(defn get-metadata
-  [search-endpoint user-token params]
-  (let [results @(async-get-metadata search-endpoint user-token params)]
+(defn extract-metadata
+  [promise]
+  (let [results @promise]
     (log/debug "Got results from CMR granule search:" results)
     (get-in results [:feed :entry])))
+
+(defn get-metadata
+  [search-endpoint user-token params]
+  (let [promise (async-get-metadata search-endpoint user-token params)]
+    (extract-metadata promise)))
 
 ;; XXX This logic was copied from the prototype; it is generally viewed by the
 ;;     CMR Team & the Metadata Tools Team that this approach is flawed, and

--- a/src/cmr/opendap/ous/service.clj
+++ b/src/cmr/opendap/ous/service.clj
@@ -31,11 +31,16 @@
          (request/add-accept "application/vnd.nasa.cmr.umm+json"))
      response/json-handler)))
 
-(defn get-metadata
-  [search-endpoint user-token service-ids]
-  (let [results @(async-get-metadata search-endpoint user-token service-ids)]
+(defn extract-metadata
+  [promise]
+  (let [results @promise]
     (log/debug "Got results from CMR service search:" results)
     (:items results)))
+
+(defn get-metadata
+  [search-endpoint user-token service-ids]
+  (let [promise (async-get-metadata search-endpoint user-token service-ids)]
+    (extract-metadata promise)))
 
 (defn match-opendap
   [service-data]

--- a/src/cmr/opendap/ous/variable.clj
+++ b/src/cmr/opendap/ous/variable.clj
@@ -207,6 +207,12 @@
          variable-ids)
     (str "page_size=" (count variable-ids)))))
 
+(defn extract-metadata
+  [promise]
+  (let [results @promise]
+    (log/debug "Got results from CMR variable search:" results)
+    (:items results)))
+
 (defn get-metadata
   "Given a 'params' data structure with a ':variables' key (which may or may
   not have values) and a list of all collection variable-ids, return the
@@ -217,14 +223,13 @@
     (let [url (str search-endpoint
                    "/variables?"
                    (build-query variable-ids))
-          results (request/async-get url
+          promise (request/async-get url
                    (-> {}
                        (request/add-token-header user-token)
                        (request/add-accept "application/vnd.nasa.cmr.umm+json"))
                    response/json-handler)]
-      (log/debug "Got results from CMR variable search:" results)
       (log/debug "Variable ids used:" variable-ids)
-      (:items @results))
+      (extract-metadata promise))
     []))
 
 (defn parse-dimensions

--- a/src/cmr/opendap/ous/variable.clj
+++ b/src/cmr/opendap/ous/variable.clj
@@ -9,6 +9,42 @@
    [taoensso.timbre :as log]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;   Notes   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; Notes on representing spatial extents.
+;;
+;; EDSC uses URL-encoded long/lat numbers representing a bounding box
+;; Note that the ordering is the same as that used by CMR (see below).
+;;  `-9.984375%2C56.109375%2C19.828125%2C67.640625`
+;; which URL-decodes to:
+;;  `-9.984375,56.109375,19.828125,67.640625`
+;;
+;; OPeNDAP download URLs have something I haven't figured out yet; given that
+;; one of the numbers if over 180, it can't be degrees ... it might be what
+;; WCS uses for `x` and `y`?
+;;  `Latitude[22:34],Longitude[169:200]`
+;;
+;; The OUS Prototype uses the WCS standard for lat/long:
+;;  `SUBSET=axis[,crs](low,high)`
+;; For lat/long this takes the following form:
+;;  `subset=lat(56.109375,67.640625)&subset=lon(-9.984375,19.828125)`
+;;
+;; CMR supports bounding spatial extents by describing a rectangle using four
+;; comma-separated values:
+;;  1. lower left longitude
+;;  2. lower left latitude
+;;  3. upper right longitude
+;;  4. upper right latitude
+;; For example:
+;;  `bounding_box==-9.984375,56.109375,19.828125,67.640625`
+;;
+;; Google's APIs use lower left, upper right, but the specify lat first, then
+;; long:
+;;  `southWest = LatLng(56.109375,-9.984375);`
+;;  `northEast = LatLng(67.640625,19.828125);`
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;   Constants/Default Values   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -27,6 +63,10 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;   Records   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;
+;;; We're going to codify parameters with records to keep things well
+;;; documented. Additionally, this will make converting between parameter
+;;; schemes an explicit operation on explicit data.
 
 (defrecord Dimensions [x y])
 (defrecord ArrayLookup [low high])

--- a/src/cmr/opendap/rest/app.clj
+++ b/src/cmr/opendap/rest/app.clj
@@ -38,8 +38,9 @@
         all-routes
         (ring/router (middleware/reitit-auth httpd-component))
         ring/ring-handler
-        (ring-defaults/wrap-defaults ring-defaults/api-defaults)
-        (middleware/wrap-resource httpd-component)
-        middleware/wrap-trailing-slash
-        middleware/wrap-cors
-        (middleware/wrap-not-found httpd-component))))
+        ; (ring-defaults/wrap-defaults ring-defaults/api-defaults)
+        ; (middleware/wrap-resource httpd-component)
+        ; middleware/wrap-trailing-slash
+        ; middleware/wrap-cors
+        ; (middleware/wrap-not-found httpd-component)
+        )))

--- a/src/cmr/opendap/rest/app.clj
+++ b/src/cmr/opendap/rest/app.clj
@@ -38,9 +38,8 @@
         all-routes
         (ring/router (middleware/reitit-auth httpd-component))
         ring/ring-handler
-        ; (ring-defaults/wrap-defaults ring-defaults/api-defaults)
-        ; (middleware/wrap-resource httpd-component)
-        ; middleware/wrap-trailing-slash
-        ; middleware/wrap-cors
-        ; (middleware/wrap-not-found httpd-component)
-        )))
+        (ring-defaults/wrap-defaults ring-defaults/api-defaults)
+        (middleware/wrap-resource httpd-component)
+        middleware/wrap-trailing-slash
+        middleware/wrap-cors
+        (middleware/wrap-not-found httpd-component))))

--- a/src/cmr/opendap/rest/handler/collection.clj
+++ b/src/cmr/opendap/rest/handler/collection.clj
@@ -71,10 +71,6 @@
   [request]
   (log/debug "Processing stream request ...")
   (server/with-channel request channel
-    ; (server/send! channel
-    ;               {:headers {"Content-Type" "text/event-stream; charset=utf-8"
-    ;                          "Cache-Control" "no-cache"}}
-    ;               false)
     (log/debug "Setting 'on-close' callback ...")
     (server/on-close channel
                      (fn [status]
@@ -85,12 +81,9 @@
       (when (< id 10)
         (timer/schedule-task
          (* id 200) ;; send a message every 200ms
-         ; (let [msg (format "message #%s from server ..." id)]
-         ;  (server/send! channel (format "%x\r\n%s\r\n" (count msg) msg) false))) ; false => don't close after send
          (log/debug "\tSending chunk to client ...")
          (server/send! channel
-                       ;(format "%x\r\nmessage #%s from server ..." id id)
                        (format "message #%s from server ..." id)
                        false))
         (recur (inc id))))
-    (timer/schedule-task 20000 (server/close channel))))
+    (timer/schedule-task (* 10 200) (server/close channel))))

--- a/src/cmr/opendap/rest/handler/collection.clj
+++ b/src/cmr/opendap/rest/handler/collection.clj
@@ -78,7 +78,7 @@
     (log/debug "Setting 'on-close' callback ...")
     (server/on-close channel
                      (fn [status]
-                      (println "channel closed, " status)))
+                      (println "Channel closed; status " status)))
     (log/debug "Starting loop ...")
     (loop [id 0]
       (log/debug "Loop id:" id)
@@ -87,7 +87,9 @@
          (* id 200) ;; send a message every 200ms
          ; (let [msg (format "message #%s from server ..." id)]
          ;  (server/send! channel (format "%x\r\n%s\r\n" (count msg) msg) false))) ; false => don't close after send
+         (log/debug "\tSending chunk to client ...")
          (server/send! channel
+                       ;(format "%x\r\nmessage #%s from server ..." id id)
                        (format "message #%s from server ..." id)
                        false))
         (recur (inc id))))

--- a/src/cmr/opendap/rest/middleware.clj
+++ b/src/cmr/opendap/rest/middleware.clj
@@ -125,3 +125,10 @@
   For more details, see the docstring above for `wrap-auth`."
   {:data
     {:middleware [#(wrap-auth % system)]}})
+
+
+(defn manager
+  ""
+  [handler system]
+  (fn [request]
+    ))

--- a/src/cmr/opendap/rest/route.clj
+++ b/src/cmr/opendap/rest/route.clj
@@ -42,7 +42,8 @@
   [httpd-component]
   [["/opendap/ous/collections" {
     :post {:handler collection-handler/batch-generate
-          ;; XXX protecting collections will be a little different than
+          ;; XXX CMR-
+          ;;     Protecting collections will be a little different than
           ;;     protecting a single collection, since the concept-id isn't in
           ;;     the path-params. Instead, we'll have to parse the body,
           ;;     extract the concepts ids from that, create an ACL query
@@ -56,7 +57,7 @@
     :post {:handler (collection-handler/generate-urls httpd-component)
            :permissions #{:read}}
     :options core-handler/ok}]
-   ["/opendap/stream" {:get collection-handler/stream}]])
+   ["/opendap/ous/stream" {:get collection-handler/stream}]])
 
 (defn admin-api
   [httpd-component]

--- a/src/cmr/opendap/rest/route.clj
+++ b/src/cmr/opendap/rest/route.clj
@@ -55,7 +55,8 @@
           :permissions #{:read}}
     :post {:handler (collection-handler/generate-urls httpd-component)
            :permissions #{:read}}
-    :options core-handler/ok}]])
+    :options core-handler/ok}]
+   ["/opendap/stream" {:get collection-handler/stream}]])
 
 (defn admin-api
   [httpd-component]

--- a/src/cmr/opendap/rest/route.clj
+++ b/src/cmr/opendap/rest/route.clj
@@ -57,7 +57,8 @@
     :post {:handler (collection-handler/generate-urls httpd-component)
            :permissions #{:read}}
     :options core-handler/ok}]
-   ["/opendap/ous/stream/collection/:concept-id" {:get collection-handler/stream}]])
+   ["/opendap/ous/stream/collection/:concept-id" {
+    :get collection-handler/stream-urls}]])
 
 (defn admin-api
   [httpd-component]

--- a/src/cmr/opendap/rest/route.clj
+++ b/src/cmr/opendap/rest/route.clj
@@ -57,7 +57,7 @@
     :post {:handler (collection-handler/generate-urls httpd-component)
            :permissions #{:read}}
     :options core-handler/ok}]
-   ["/opendap/ous/stream" {:get collection-handler/stream}]])
+   ["/opendap/ous/stream/collection/:concept-id" {:get collection-handler/stream}]])
 
 (defn admin-api
   [httpd-component]

--- a/src/cmr/opendap/rest/route.clj
+++ b/src/cmr/opendap/rest/route.clj
@@ -58,7 +58,7 @@
            :permissions #{:read}}
     :options core-handler/ok}]
    ["/opendap/ous/stream/collection/:concept-id" {
-    :get collection-handler/stream-urls}]])
+    :get (collection-handler/stream-urls httpd-component)}]])
 
 (defn admin-api
   [httpd-component]


### PR DESCRIPTION
Explore streaming as a way of supporting internal (to CMR OPeNDAP) async -- in an effort to decrease load on threadpool -- without negatively impacting API clients/consumers (instead of having to convert to async, they just need to support streaming data).