### PR TITLE
Feature/cmr search bounding box

### DIFF
--- a/src/cmr/opendap/ous/collection/core.clj
+++ b/src/cmr/opendap/ous/collection/core.clj
@@ -17,6 +17,7 @@
   (let [url (str search-endpoint
                  "/collections?"
                  (build-query params))]
+    (log/debug "Collection query to CMR:" url)
     (request/async-get
      url
      (-> {}
@@ -27,7 +28,7 @@
 (defn extract-metadata
   [promise]
   (let [results @promise]
-    (log/debug "Got results from CMR granule collection:" results)
+    (log/trace "Got results from CMR granule collection:" results)
     (first (get-in results [:feed :entry]))))
 
 (defn get-metadata

--- a/src/cmr/opendap/ous/core.clj
+++ b/src/cmr/opendap/ous/core.clj
@@ -117,12 +117,21 @@
 ;;;   Stages for URL Generation   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;
-;;; The functions originally called as part of a `let` block in
-;;; `get-opendap-urls` have been split out into stages organized by dependency.
+;;; The various stage functions below were originally called as part of a `let`
+;;; block in `get-opendap-urls` but now have been split out into stages
+;;; organized by dependency.
+;;;
+;;; In particular:
+;;;
 ;;; Functions which depend only upon the parameters (or parsing of those
 ;;; parameters) are placed in the first stage. Functions which depend upon
 ;;; either the parameters or the results of the first stage are placed in the
 ;;; second stage, etc.
+;;;
+;;; The reason for this was to make it very clear when various functions
+;;; could be called as late as possible, and only call those which were
+;;; absolutely necessary at a given point. And the reason for _that_ was so
+;;; the code could be properly prepared for async execution.
 
 (defn stage1
   [search-endpoint user-token raw-params]
@@ -167,7 +176,7 @@
         pattern-info (service/extract-pattern-info (first services))
         query (bounding-info->opendap-query bounding-info bounding-box)]
     (log/trace "pattern-info:" pattern-info)
-    (log/debug "query:" query)
+    (log/debug "Generated OPeNDAP query:" query)
     (log/debug "Finishing stage 4 ...")
     [pattern-info query]))
 

--- a/src/cmr/opendap/ous/service.clj
+++ b/src/cmr/opendap/ous/service.clj
@@ -24,6 +24,7 @@
   (let [url (str search-endpoint
                  "/services?"
                  (build-query service-ids))]
+    (log/debug "Services query to CMR:" url)
     (request/async-get
      url
      (-> {}
@@ -34,7 +35,7 @@
 (defn extract-metadata
   [promise]
   (let [results @promise]
-    (log/debug "Got results from CMR service search:" results)
+    (log/trace "Got results from CMR service search:" results)
     (:items results)))
 
 (defn get-metadata

--- a/src/cmr/opendap/ous/util.clj
+++ b/src/cmr/opendap/ous/util.clj
@@ -23,6 +23,10 @@
         (coll? data) data
         (string? data) (string/split data #",")))
 
+(defn seq->str
+  [data]
+  (string/join "," data))
+
 (defn bounding-box->subset
   [[lon-lo lat-lo lon-hi lat-hi]]
   [(format "lat(%s,%s)" lat-lo lat-hi)

--- a/src/cmr/opendap/ous/variable.clj
+++ b/src/cmr/opendap/ous/variable.clj
@@ -210,7 +210,7 @@
 (defn extract-metadata
   [promise]
   (let [results @promise]
-    (log/debug "Got results from CMR variable search:" results)
+    (log/trace "Got results from CMR variable search:" results)
     (:items results)))
 
 (defn get-metadata
@@ -223,6 +223,7 @@
     (let [url (str search-endpoint
                    "/variables?"
                    (build-query variable-ids))
+          _ (log/debug "Variables query to CMR:" url)
           promise (request/async-get url
                    (-> {}
                        (request/add-token-header user-token)


### PR DESCRIPTION
This passes any bounding box information in the CMR OPeNDAP parameter records on to CMR when granules queries are issued by CMR OPeNDAP to CMR Search.